### PR TITLE
add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+# manual release
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    permissions:
+      contents: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+
+      - name: Install Dependencies
+        run: npm ci
+
+      # Extract version from package.json
+      - id: pkg_version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+      # Check if tag already exists
+      - name: Check if tag exists
+        run: |
+          if git rev-parse "v${{ steps.pkg_version.outputs.version }}" >/dev/null 2>&1; then
+            echo "Tag v${{ steps.pkg_version.outputs.version }} already exists!"
+            exit 1
+          fi
+
+      - name: Build Project
+        run: npm run build
+
+      - name: Archive output directory
+        run: zip -r build.zip out/
+
+      # Create a GitHub release
+      - name: Create Release
+        id: create_release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "build.zip"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: v${{ steps.pkg_version.outputs.version }}
+          name: Release v${{ steps.pkg_version.outputs.version }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
refs #36

Now think that this probably can be postponed, because it will be more useful for later - when we are worried about breaking stuff and have a separate test and prod versions. So I'll just leave this PR hanging in draft for now.

By test version I mean a version of the website which works only with testnet and can be tested by a few volunteers from the community, who are ready to encounter and report bugs, and that version should be updated as soon as we merge something to main.

The current `release.yml` here is somewhat different  - it makes it possible to build directly GitHub CI by launching manually in GitHub UI: `Actions` -> `Release`. The result is `build.zip` which contains what we usually get in `out` folder when we run `npm run build`. 

The idea is to use releases for later deployment when we are ready to share a bunch of updates together with a wider community (and currently it's to test how it easy or not it would be to deploy in this format). It would also be helpful if we decide to distribute the code for people to deploy themselves.