### PR TITLE
Update navbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "dexter-dapp",
       "version": "0.1.0",
       "dependencies": {
-        "@radixdlt/radix-dapp-toolkit": "^0.5.1",
+        "@heroicons/react": "^2.0.18",
+        "@radixdlt/radix-dapp-toolkit": "^0.6.1",
         "@reduxjs/toolkit": "^1.9.5",
         "@types/node": "20.3.3",
         "@types/react": "18.2.14",
@@ -802,6 +803,14 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@heroicons/react": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.0.18.tgz",
+      "integrity": "sha512-7TyMjRrZZMBPa+/5Y8lN0iyvUU/01PeMGX2+RE7cQWpEUIcb4QotzUObFkJDejj/HUH4qjP/eQ0gzzKs2f+6Yw==",
+      "peerDependencies": {
+        "react": ">= 16"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
@@ -1586,14 +1595,14 @@
       }
     },
     "node_modules/@radixdlt/babylon-gateway-api-sdk": {
-      "version": "1.0.0-rc.3.3",
-      "resolved": "https://registry.npmjs.org/@radixdlt/babylon-gateway-api-sdk/-/babylon-gateway-api-sdk-1.0.0-rc.3.3.tgz",
-      "integrity": "sha512-c723dWAbBTUxKcK1WPS2b9kSJMd7OcgJ6nZR+VBwPmFZYh9gWkD75fxCi0XaeZL7xaib6N3BEPEpjYqEllRwcg=="
+      "version": "1.0.0-rc.3.2",
+      "resolved": "https://registry.npmjs.org/@radixdlt/babylon-gateway-api-sdk/-/babylon-gateway-api-sdk-1.0.0-rc.3.2.tgz",
+      "integrity": "sha512-7odQHQARzK1HIwpqjdH3ZHcYLpywHfZXdLRBw+1Lpx8cQ4X8nUeIwlEns3+g5XhX8+2dfOdQnumSsN/BcL41BA=="
     },
     "node_modules/@radixdlt/connect-button": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/@radixdlt/connect-button/-/connect-button-0.13.3.tgz",
-      "integrity": "sha512-XUj47PBO81hW4gQ4ViNhJaoaOjGZcGEEMvVi+r0u8wPTpyeGRwd+lX8Kyp0nNpTLASaNdZadM6bO/18RNZ/yGg==",
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@radixdlt/connect-button/-/connect-button-0.13.4.tgz",
+      "integrity": "sha512-5jeiiFJLBnJzC3nimWY7sKzQgRgtHAb0rMRjxtBxdBusr/HjTIoedLmOHBv5Yc+kpJSKAdtBp/PovaVOcM06qQ==",
       "dependencies": {
         "lit": "^2.7.5"
       },
@@ -1602,13 +1611,13 @@
       }
     },
     "node_modules/@radixdlt/radix-dapp-toolkit": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@radixdlt/radix-dapp-toolkit/-/radix-dapp-toolkit-0.5.1.tgz",
-      "integrity": "sha512-DHZK0gTiHGBRcQBfSw1xnDZWAMvjaJeLz9r/hm1aAfkYIiuf0u3xsHiihHCE9pxksVECCir0GFXgNu8Gc9B6ng==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@radixdlt/radix-dapp-toolkit/-/radix-dapp-toolkit-0.6.1.tgz",
+      "integrity": "sha512-rVU71RYbF8ZkBMWtzN2Gr1PrcdSdAjxGUBeDBq/hB2aAo9hvOjURbvoQWTylEJznOQfINQM9IWVHNSfAUuCZ6g==",
       "dependencies": {
-        "@radixdlt/babylon-gateway-api-sdk": "^1.0.0-rc.2.4",
-        "@radixdlt/connect-button": "0.13.3",
-        "@radixdlt/wallet-sdk": "0.10.0",
+        "@radixdlt/babylon-gateway-api-sdk": "1.0.0-rc.3.2",
+        "@radixdlt/connect-button": "0.13.4",
+        "@radixdlt/wallet-sdk": "0.10.1-alpha.1",
         "immer": "^10.0.2",
         "lodash.isequal": "^4.5.0",
         "neverthrow": "^6.0.0",
@@ -1620,9 +1629,9 @@
       }
     },
     "node_modules/@radixdlt/wallet-sdk": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@radixdlt/wallet-sdk/-/wallet-sdk-0.10.0.tgz",
-      "integrity": "sha512-BzW1X5cEq4Rax8WP+zPEC3hDQammdTtWrnyaqFRshhMEeFN1bPVc8OxEghwDDRWwCWVqAa9FSfLPsmcCXAbZmw==",
+      "version": "0.10.1-alpha.1",
+      "resolved": "https://registry.npmjs.org/@radixdlt/wallet-sdk/-/wallet-sdk-0.10.1-alpha.1.tgz",
+      "integrity": "sha512-kCmCLJ3Yi2VZhN7/B9nhnTi6JNuiy8+otQy3kh1JNb0pd9CV6o6YS/Vj85mVoGtePVog4UHmu6RKFbPR9TVrfg==",
       "dependencies": {
         "neverthrow": "^6.0.0",
         "rxjs": "^7.8.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "jest __tests__ --watch"
   },
   "dependencies": {
-    "@radixdlt/radix-dapp-toolkit": "^0.5.1",
+    "@heroicons/react": "^2.0.18",
+    "@radixdlt/radix-dapp-toolkit": "^0.6.1",
     "@reduxjs/toolkit": "^1.9.5",
     "@types/node": "20.3.3",
     "@types/react": "18.2.14",

--- a/public/logo_icon.svg
+++ b/public/logo_icon.svg
@@ -1,0 +1,9 @@
+<svg width="105" height="104" viewBox="0 0 105 104" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Logo / Icon">
+<g id="Vector">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M33.2687 52.4493L0 28.8497L12.8245 11.0235L71.1688 52.4107L15.1183 92.3432L2.25711 74.5431L33.2687 52.4493Z" fill="#CBFC42"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M105 28.8001L76.7021 47.5319L58.798 34.7533L92.1388 11L105 28.8001Z" fill="#CBFC42"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M76.7021 57.3366L103.126 75.1524L90.3317 93L58.8212 70.7269L76.7021 57.3366Z" fill="#CBFC42"/>
+</g>
+</g>
+</svg>

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -1,5 +1,8 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Image from "next/image";
+import { MoonIcon } from "@heroicons/react/24/outline";
+
+// TODO: theme switching
 
 export function Navbar() {
   return (
@@ -19,8 +22,16 @@ export function Navbar() {
           <span className="xs:invisible sm:visible uppercase">DeXter</span>
         </a>
       </div>
+
       <div className="navbar-end">
-        <radix-connect-button className="btn"></radix-connect-button>
+        <div
+          className="btn mx-2 border-none"
+          style={{ height: "40px", minHeight: "40px" }}
+        >
+          <MoonIcon className="h-6 w-6" />
+        </div>
+
+        <radix-connect-button></radix-connect-button>
       </div>
     </div>
   );

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -1,10 +1,23 @@
 import React from "react";
+import Image from "next/image";
 
 export function Navbar() {
   return (
     <div className="col-span-12 navbar">
       <div className="navbar-start">
-        <a className="btn btn-ghost normal-case text-xl">DeXter</a>
+        <a
+          href="/"
+          className="btn btn-ghost hover:bg-transparent no-underline text-xl p-0"
+        >
+          <Image
+            src="/logo_icon.svg"
+            alt="Dexter Logo"
+            width={40}
+            height={40}
+            className="!my-0"
+          />
+          <span className="xs:invisible sm:visible uppercase">DeXter</span>
+        </a>
       </div>
       <div className="navbar-end">
         <radix-connect-button className="btn"></radix-connect-button>

--- a/src/app/declarations.d.ts
+++ b/src/app/declarations.d.ts
@@ -3,3 +3,12 @@ interface Window {
     showModal: () => void;
   };
 }
+
+namespace JSX {
+  interface IntrinsicElements {
+    "radix-connect-button": React.DetailedHTMLProps<
+      React.HTMLAttributes<HTMLElement>,
+      HTMLElement
+    >;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,18 +11,6 @@ import { Provider } from "react-redux";
 
 const inter = Inter({ subsets: ["latin"] });
 
-// declare the radix-connect-button as a global custom element
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      "radix-connect-button": React.DetailedHTMLProps<
-        React.HTMLAttributes<HTMLElement>,
-        HTMLElement
-      >;
-    }
-  }
-}
-
 export default function RootLayout({
   children,
 }: {

--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --radix-connect-button-height: 40px;
+}
+
 /* remove up and down arrows on number input fields */
 
 /* For Firefox */

--- a/src/app/subscriptions.ts
+++ b/src/app/subscriptions.ts
@@ -43,6 +43,8 @@ export function initializeSubscriptions(store: AppStore) {
     })
   );
   setRdt(rdtInstance);
+  // TODO: "black" on the light theme
+  rdtInstance.buttonApi.setTheme("white");
   adex.init();
   subs.push(
     adex.clientState.stateChanged$.subscribe((newState) => {


### PR DESCRIPTION
closes #98 

- adds logo
- adds a button for future theme changes
- fixes transparency issue
- white connect button for the dark theme

Radix [new connect buttons](https://connect-button-storybook.radixdlt.com/?path=/story/components-button--themes) are not very flexible style-wise after all, after you connect they are still blue (plus other shades). And all the sub-menus after click are still not easily stylable. Maybe we can hack inside the component and override the css somehow?

I went with the white one on dark theme (with the idea of using black with the light theme later) for contrast - but that's on the right of a suggestion. 

Also I set the heights of both theme-changing button and connect button to fixed 40px. Is that all right?

![Screenshot 2023-09-06 at 17 42 21](https://github.com/DeXter-on-Radix/website/assets/27793901/9bf18d82-68d9-4110-b8d1-68e5af782616)
![Screenshot 2023-09-06 at 17 34 15](https://github.com/DeXter-on-Radix/website/assets/27793901/643463b6-0b77-46e1-96ab-3bb03adfd04a)
![Screenshot 2023-09-06 at 17 32 35](https://github.com/DeXter-on-Radix/website/assets/27793901/d7d49648-76a7-424b-860b-a51fc622a5ff)
