### PR TITLE
Read locale separators

### DIFF
--- a/src/app/redux/UiSlice.ts
+++ b/src/app/redux/UiSlice.ts
@@ -1,0 +1,26 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+export interface UiState {
+  decimalSeparator: string;
+  thousandsSeparator: string;
+}
+
+const initialState: UiState = {
+  decimalSeparator: ".",
+  thousandsSeparator: " ",
+};
+
+export const uiSlice = createSlice({
+  name: "ui",
+  initialState,
+
+  // synchronous reducers
+  reducers: {
+    setDecimalSeparator: (state: UiState, action: PayloadAction<string>) => {
+      state.decimalSeparator = action.payload;
+    },
+    setThousandsSeparator: (state: UiState, action: PayloadAction<string>) => {
+      state.thousandsSeparator = action.payload;
+    },
+  },
+});

--- a/src/app/redux/store.ts
+++ b/src/app/redux/store.ts
@@ -5,9 +5,11 @@ import { orderBookSlice } from "./orderBookSlice";
 import { priceChartSlice } from "./priceChartSlice";
 import { accountHistorySlice } from "./accountHistorySlice";
 import { radixSlice } from "./radixSlice";
+import { uiSlice } from "./UiSlice";
 
 export const store = configureStore({
   reducer: {
+    ui: uiSlice.reducer,
     radix: radixSlice.reducer,
     pairSelector: pairSelectorSlice.reducer,
     orderInput: orderInputSlice.reducer,

--- a/src/app/subscriptions.ts
+++ b/src/app/subscriptions.ts
@@ -11,6 +11,8 @@ import { orderBookSlice } from "./redux/orderBookSlice";
 import { updateCandles } from "./redux/priceChartSlice";
 import { accountHistorySlice } from "./redux/accountHistorySlice";
 import { AppStore } from "./redux/store";
+import { getLocaleSeparators } from "utils";
+import { uiSlice } from "redux/UiSlice";
 
 export type RDT = ReturnType<typeof RadixDappToolkit>;
 
@@ -58,6 +60,11 @@ export function initializeSubscriptions(store: AppStore) {
       store.dispatch(accountHistorySlice.actions.updateAdex(serializedState));
     })
   );
+
+  // determine separators to be used when displaying numbers
+  let { decimalSeparator, thousandsSeparator } = getLocaleSeparators();
+  store.dispatch(uiSlice.actions.setDecimalSeparator(decimalSeparator));
+  store.dispatch(uiSlice.actions.setThousandsSeparator(thousandsSeparator));
 }
 
 export function unsubscribeAll() {

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -9,6 +9,18 @@ export function displayPositiveNumber(x: number, decimals: number): string {
   }
 }
 
+export function getLocaleSeparators(): {
+  decimalSeparator: string;
+  thousandsSeparator: string;
+} {
+  let decimalSeparator = Number(1.1).toLocaleString().substring(1, 2);
+  let thousandsSeparator = Number(10000).toLocaleString().substring(2, 3);
+  return {
+    decimalSeparator,
+    thousandsSeparator,
+  };
+}
+
 export function displayAmount(
   x: number,
   noDigits: number = 6,

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -1,5 +1,7 @@
 // utiluty function to display numbers in a fixed format
 
+import { store } from "redux/store";
+
 export function displayPositiveNumber(x: number, decimals: number): string {
   // the same as with displayNumber, but if the number is negative, it will return empty string
   if (x < 0) {
@@ -24,15 +26,18 @@ export function getLocaleSeparators(): {
 export function displayAmount(
   x: number,
   noDigits: number = 6,
-  decimalSeparator: string = ".",
-  thousandsSeparator: string = " ",
+  decimalSeparator: string | undefined = undefined,
+  thousandsSeparator: string | undefined = undefined,
   fixedDecimals: number = -1
 ): string {
   if (noDigits < 4) {
     return "ERROR: displayAmount cannot work with noDigits less than 4";
   }
-  if (decimalSeparator == "") {
-    return 'ERROR: desiplayAmount decimalSeparator cannot be ""';
+  if (!decimalSeparator) {
+    decimalSeparator = store.getState().ui.decimalSeparator;
+  }
+  if (!thousandsSeparator) {
+    thousandsSeparator = store.getState().ui.thousandsSeparator;
   }
   if (x < 1) {
     let roundedNumber = roundTo(x, noDigits - 2, RoundType.DOWN);


### PR DESCRIPTION
Addresses issue #76
I added a utility function to read the locale specific separators to use when displaying amounts.
I added this function to run when the app initialises and store the separator values in a ui state.
The displayAmount function then uses these separtors by default.
