### PR TITLE
Price info bar component

### DIFF
--- a/src/app/components/PriceInfo.tsx
+++ b/src/app/components/PriceInfo.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { useAppSelector } from "../hooks";
+
+export function PriceInfo() {
+  const priceInfo = useAppSelector((state) => state.priceInfo);
+  const lastPrice = priceInfo.lastPrice;
+  const change = priceInfo.change24h;
+  const high = priceInfo.high24h;
+  const low = priceInfo.low24h;
+  const volume = priceInfo.value24h;
+  //   const open = priceInfo.open24h;
+
+  return (
+    <div className="flex justify-between py-2">
+      {" "}
+      <div className="flex flex-col items-start pl-8">
+        {" "}
+        <span className="text-sm">Price</span>
+        <span className="text-xs">{lastPrice}</span>{" "}
+      </div>
+      <div className="flex flex-col items-start">
+        <span className="text-sm">24h Change</span>
+        <span className="text-xs">{change}</span>
+      </div>
+      <div className="flex flex-col items-start">
+        <span className="text-sm">24h High</span>
+        <span className="text-xs">{high}</span>
+      </div>
+      <div className="flex flex-col items-start">
+        <span className="text-sm">24h Low</span>
+        <span className="text-xs">{low}</span>
+      </div>
+      <div className="flex flex-col items-start pr-8">
+        {" "}
+        <span className="text-sm">24h Volume</span>
+        <span className="text-xs">{volume}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/PriceInfo.tsx
+++ b/src/app/components/PriceInfo.tsx
@@ -8,32 +8,60 @@ export function PriceInfo() {
   const high = priceInfo.high24h;
   const low = priceInfo.low24h;
   const volume = priceInfo.value24h;
+  const isNegativeOrZero = priceInfo.isNegativeOrZero;
   //   const open = priceInfo.open24h;
 
   return (
     <div className="flex justify-between py-2">
-      {" "}
       <div className="flex flex-col items-start pl-8">
-        {" "}
         <span className="text-sm">Price</span>
-        <span className="text-xs">{lastPrice}</span>{" "}
+        <span
+          className={
+            isNegativeOrZero ? "text-xs text-red-500" : "text-xs text-green-500"
+          }
+        >
+          {lastPrice}
+        </span>
       </div>
       <div className="flex flex-col items-start">
         <span className="text-sm">24h Change</span>
-        <span className="text-xs">{change}</span>
+        <span
+          className={
+            isNegativeOrZero ? "text-xs text-red-500" : "text-xs text-green-500"
+          }
+        >
+          {change}
+        </span>
       </div>
       <div className="flex flex-col items-start">
         <span className="text-sm">24h High</span>
-        <span className="text-xs">{high}</span>
+        <span
+          className={
+            isNegativeOrZero ? "text-xs text-red-500" : "text-xs text-green-500"
+          }
+        >
+          {high}
+        </span>
       </div>
       <div className="flex flex-col items-start">
         <span className="text-sm">24h Low</span>
-        <span className="text-xs">{low}</span>
+        <span
+          className={
+            isNegativeOrZero ? "text-xs text-red-500" : "text-xs text-green-500"
+          }
+        >
+          {low}
+        </span>
       </div>
       <div className="flex flex-col items-start pr-8">
-        {" "}
         <span className="text-sm">24h Volume</span>
-        <span className="text-xs">{volume}</span>
+        <span
+          className={
+            isNegativeOrZero ? "text-xs text-red-500" : "text-xs text-green-500"
+          }
+        >
+          {volume}
+        </span>
       </div>
     </div>
   );

--- a/src/app/components/PriceInfo.tsx
+++ b/src/app/components/PriceInfo.tsx
@@ -9,7 +9,6 @@ export function PriceInfo() {
   const low = priceInfo.low24h;
   const volume = priceInfo.value24h;
   const isNegativeOrZero = priceInfo.isNegativeOrZero;
-  //   const open = priceInfo.open24h;
 
   return (
     <div className="flex justify-between py-2">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { OrderInput } from "components/OrderInput";
 import { PairSelector } from "components/PairSelector";
 import { PriceChart } from "components/PriceChart";
 import { AccountHistory } from "components/AccountHistory";
+import { PriceInfo } from "components/PriceInfo";
 
 export default function Home() {
   return (
@@ -13,7 +14,7 @@ export default function Home() {
         <PairSelector />
       </div>
       <div className="min-h-[50px] col-span-12 lg:col-span-7 xl:col-span-6 text-center">
-        Price Info
+        <PriceInfo />
       </div>
       <div className="col-span-12 xl:col-span-3 hidden xl:block  row-span-2 text-center border-l-4 border-base-300">
         <OrderBook />

--- a/src/app/redux/priceInfoSlice.ts
+++ b/src/app/redux/priceInfoSlice.ts
@@ -1,0 +1,43 @@
+import * as adex from "alphadex-sdk-js";
+import { PayloadAction, createSlice } from "@reduxjs/toolkit";
+import { RootState } from "./store";
+
+// Define the state type
+export interface PriceInfoState {
+  lastPrice: number;
+  open24h: number;
+  change24h: number;
+  high24h: number;
+  low24h: number;
+  value24h: number;
+}
+
+// Define the initial state with type
+const initialState: PriceInfoState = {
+  lastPrice: adex.clientState.currentPairInfo.lastPrice,
+  open24h: adex.clientState.currentPairInfo.open24h,
+  change24h: adex.clientState.currentPairInfo.change24h,
+  high24h: adex.clientState.currentPairInfo.high24h,
+  low24h: adex.clientState.currentPairInfo.low24h,
+  value24h: adex.clientState.currentPairInfo.value24h,
+};
+
+// Create the slice with reducers and actions
+export const priceInfoSlice = createSlice({
+  name: "priceInfo",
+  initialState,
+  reducers: {
+    updatePriceInfo: (state, action: PayloadAction<adex.StaticState>) => {
+      state.lastPrice = action.payload.currentPairInfo.lastPrice;
+      state.open24h = action.payload.currentPairInfo.open24h;
+      state.change24h = action.payload.currentPairInfo.change24h;
+      state.high24h = action.payload.currentPairInfo.high24h;
+      state.low24h = action.payload.currentPairInfo.low24h;
+      state.value24h = action.payload.currentPairInfo.value24h;
+    },
+  },
+});
+
+// Export the actions and reducer
+export const { updatePriceInfo } = priceInfoSlice.actions;
+export default priceInfoSlice.reducer;

--- a/src/app/redux/priceInfoSlice.ts
+++ b/src/app/redux/priceInfoSlice.ts
@@ -1,8 +1,6 @@
 import * as adex from "alphadex-sdk-js";
 import { PayloadAction, createSlice } from "@reduxjs/toolkit";
-import { RootState } from "./store";
 
-// Define the state type
 export interface PriceInfoState {
   lastPrice: number;
   open24h: number;
@@ -10,34 +8,37 @@ export interface PriceInfoState {
   high24h: number;
   low24h: number;
   value24h: number;
+  isNegativeOrZero: boolean;
 }
 
-// Define the initial state with type
+const currentPairInfo = adex.clientState.currentPairInfo;
+
 const initialState: PriceInfoState = {
-  lastPrice: adex.clientState.currentPairInfo.lastPrice,
-  open24h: adex.clientState.currentPairInfo.open24h,
-  change24h: adex.clientState.currentPairInfo.change24h,
-  high24h: adex.clientState.currentPairInfo.high24h,
-  low24h: adex.clientState.currentPairInfo.low24h,
-  value24h: adex.clientState.currentPairInfo.value24h,
+  lastPrice: currentPairInfo.lastPrice,
+  open24h: currentPairInfo.open24h,
+  change24h: currentPairInfo.change24h,
+  high24h: currentPairInfo.high24h,
+  low24h: currentPairInfo.low24h,
+  value24h: currentPairInfo.value24h,
+  isNegativeOrZero: currentPairInfo.lastPrice - currentPairInfo.open24h <= 0,
 };
 
-// Create the slice with reducers and actions
 export const priceInfoSlice = createSlice({
   name: "priceInfo",
   initialState,
   reducers: {
     updatePriceInfo: (state, action: PayloadAction<adex.StaticState>) => {
-      state.lastPrice = action.payload.currentPairInfo.lastPrice;
-      state.open24h = action.payload.currentPairInfo.open24h;
-      state.change24h = action.payload.currentPairInfo.change24h;
-      state.high24h = action.payload.currentPairInfo.high24h;
-      state.low24h = action.payload.currentPairInfo.low24h;
-      state.value24h = action.payload.currentPairInfo.value24h;
+      const currentPairInfo = action.payload.currentPairInfo;
+      state.lastPrice = currentPairInfo.lastPrice;
+      state.open24h = currentPairInfo.open24h;
+      state.change24h = currentPairInfo.change24h;
+      state.high24h = currentPairInfo.high24h;
+      state.low24h = currentPairInfo.low24h;
+      state.value24h = currentPairInfo.value24h;
+      state.isNegativeOrZero =
+        currentPairInfo.lastPrice - currentPairInfo.open24h <= 0;
     },
   },
 });
 
-// Export the actions and reducer
 export const { updatePriceInfo } = priceInfoSlice.actions;
-export default priceInfoSlice.reducer;

--- a/src/app/redux/store.ts
+++ b/src/app/redux/store.ts
@@ -5,6 +5,7 @@ import { orderBookSlice } from "./orderBookSlice";
 import { priceChartSlice } from "./priceChartSlice";
 import { accountHistorySlice } from "./accountHistorySlice";
 import { radixSlice } from "./radixSlice";
+import { priceInfoSlice } from "./priceInfoSlice";
 
 export const store = configureStore({
   reducer: {
@@ -14,6 +15,7 @@ export const store = configureStore({
     orderBook: orderBookSlice.reducer,
     priceChart: priceChartSlice.reducer,
     accountHistory: accountHistorySlice.reducer,
+    priceInfo: priceInfoSlice.reducer,
   },
 });
 

--- a/src/app/subscriptions.ts
+++ b/src/app/subscriptions.ts
@@ -9,6 +9,7 @@ import { fetchBalances } from "./redux/pairSelectorSlice";
 import { pairSelectorSlice } from "./redux/pairSelectorSlice";
 import { orderBookSlice } from "./redux/orderBookSlice";
 import { updateCandles } from "./redux/priceChartSlice";
+import { updatePriceInfo } from "./redux/priceInfoSlice";
 import { accountHistorySlice } from "./redux/accountHistorySlice";
 import { AppStore } from "./redux/store";
 
@@ -55,6 +56,7 @@ export function initializeSubscriptions(store: AppStore) {
       store.dispatch(pairSelectorSlice.actions.updateAdex(serializedState));
       store.dispatch(orderBookSlice.actions.updateAdex(serializedState));
       store.dispatch(updateCandles(serializedState.currentPairCandlesList));
+      store.dispatch(updatePriceInfo(serializedState));
       store.dispatch(accountHistorySlice.actions.updateAdex(serializedState));
     })
   );


### PR DESCRIPTION
closes #81 

Finished price info component.
You can merge this first before merging the chart enhancement.

NOTE: I aware that styling is lacking for the volume xxx (xx.xx%).  I have some utils functions from the chart enhancement PR that I will be using for a next PRs after both can be merged.  I will also refactor both components (priceinfo and chart) that has similar function needs afterwards.
![20](https://github.com/DeXter-on-Radix/website/assets/107124432/1f19cdec-2503-4367-90c6-5860dbc6b020)
