### PR TITLE
alphadex version bump to 0.10.1 and radix tookit bump to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/node": "20.3.3",
         "@types/react": "18.2.14",
         "@types/react-dom": "18.2.6",
-        "alphadex-sdk-js": "^0.9.0",
+        "alphadex-sdk-js": "^0.10.1",
         "autoprefixer": "10.4.14",
         "eslint-config-next": "13.4.7",
         "lightweight-charts": "^4.0.1",
@@ -2323,9 +2323,9 @@
       }
     },
     "node_modules/alphadex-sdk-js": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/alphadex-sdk-js/-/alphadex-sdk-js-0.9.0.tgz",
-      "integrity": "sha512-6vQHDt1EK40vbt4iNV3bMqVA054r2yJIMqDR6ENQ14PVj20xpa7c57K/9FZcIvx3E94G3YKTnzqMaocc/3Mlvw==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/alphadex-sdk-js/-/alphadex-sdk-js-0.10.1.tgz",
+      "integrity": "sha512-g9KG+Uo6iw0ucn+ZWQrsXFTZugxzowxH7kYjMluMCqmqURu/kSIb9YnHn7RWH45/rlb9RvHXSsTYxhfImqCv1w==",
       "dependencies": {
         "axios": "^1.3.2",
         "rxjs": "^7.8.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dexter-dapp",
       "version": "0.1.0",
       "dependencies": {
-        "@radixdlt/radix-dapp-toolkit": "^0.7.1",
+        "@radixdlt/radix-dapp-toolkit": "^1.0.0",
         "@reduxjs/toolkit": "^1.9.5",
         "@types/node": "20.3.3",
         "@types/react": "18.2.14",
@@ -1587,14 +1587,14 @@
       }
     },
     "node_modules/@radixdlt/babylon-gateway-api-sdk": {
-      "version": "1.0.0-rc.3.1.2",
-      "resolved": "https://registry.npmjs.org/@radixdlt/babylon-gateway-api-sdk/-/babylon-gateway-api-sdk-1.0.0-rc.3.1.2.tgz",
-      "integrity": "sha512-YpPRLbFavJh5IjaKX8lRKnb8xXnQ+n7Z5hDmhJDPPYUp7zwmxc/YWtSTiC0kTpNtFeDjIgE1f+Ed1j8cUNAlbg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radixdlt/babylon-gateway-api-sdk/-/babylon-gateway-api-sdk-1.0.1.tgz",
+      "integrity": "sha512-WLfw+NuoFC04SgGKpGvkrFp67BdzCbKwklFmNjTqX9l/A0dUN820Xggf1BZ8jRUDUJI20V+fAsTTvT7ltYMJIQ=="
     },
     "node_modules/@radixdlt/connect-button": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/@radixdlt/connect-button/-/connect-button-0.13.4.tgz",
-      "integrity": "sha512-5jeiiFJLBnJzC3nimWY7sKzQgRgtHAb0rMRjxtBxdBusr/HjTIoedLmOHBv5Yc+kpJSKAdtBp/PovaVOcM06qQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radixdlt/connect-button/-/connect-button-1.0.0.tgz",
+      "integrity": "sha512-MLgKibN8dyMW2GUu89EWyJrwyMUragXKNzpzluc4PnXWBd3foNnj0RHFU1o3/PkJkfgUPxdUcIZ54JTwtQAtyQ==",
       "dependencies": {
         "lit": "^2.7.5"
       },
@@ -1603,13 +1603,13 @@
       }
     },
     "node_modules/@radixdlt/radix-dapp-toolkit": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@radixdlt/radix-dapp-toolkit/-/radix-dapp-toolkit-0.7.1.tgz",
-      "integrity": "sha512-buEpMxMZz24betg+qz6Sujk6/YnQn0yaJtQYRVC+tlLLYCPnG8d3EMvPFODJFUhWqnOJH6MJhU3Lhb38mlholQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radixdlt/radix-dapp-toolkit/-/radix-dapp-toolkit-1.0.0.tgz",
+      "integrity": "sha512-yqfjPaD+WV9mPatc9PJ8taxQiqSPoWr3c982bzwSQ1cAdyWJDIm32FuWC9koMG48B7+hekXs7PLNA1ePujnpVQ==",
       "dependencies": {
-        "@radixdlt/babylon-gateway-api-sdk": "1.0.0-rc.3.1.2",
-        "@radixdlt/connect-button": "0.13.4",
-        "@radixdlt/wallet-sdk": "0.10.1-alpha.1",
+        "@radixdlt/babylon-gateway-api-sdk": "1.0.1",
+        "@radixdlt/connect-button": "1.0.0",
+        "@radixdlt/wallet-sdk": "1.0.1",
         "immer": "^10.0.2",
         "lodash.isequal": "^4.5.0",
         "neverthrow": "^6.0.0",
@@ -1621,9 +1621,9 @@
       }
     },
     "node_modules/@radixdlt/wallet-sdk": {
-      "version": "0.10.1-alpha.1",
-      "resolved": "https://registry.npmjs.org/@radixdlt/wallet-sdk/-/wallet-sdk-0.10.1-alpha.1.tgz",
-      "integrity": "sha512-kCmCLJ3Yi2VZhN7/B9nhnTi6JNuiy8+otQy3kh1JNb0pd9CV6o6YS/Vj85mVoGtePVog4UHmu6RKFbPR9TVrfg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radixdlt/wallet-sdk/-/wallet-sdk-1.0.1.tgz",
+      "integrity": "sha512-g6TY1kUihJrECKBKs+dbTFrfzUU3bj1H2ySeaiHRNs/40eRH2Vw6heyb8DRHSkfhTzhPxXBzQxQdk908RgktUA==",
       "dependencies": {
         "neverthrow": "^6.0.0",
         "rxjs": "^7.8.1",
@@ -2025,9 +2025,9 @@
       "dev": true
     },
     "node_modules/@types/trusted-types": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
-      "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.4.tgz",
+      "integrity": "sha512-IDaobHimLQhjwsQ/NMwRVfa/yL7L/wriQPMhw1ZJall0KX6E1oxk29XMDeilW5qTIg5aoiqf5Udy8U/51aNoQQ=="
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/node": "20.3.3",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",
-    "alphadex-sdk-js": "^0.9.0",
+    "alphadex-sdk-js": "^0.10.1",
     "autoprefixer": "10.4.14",
     "eslint-config-next": "13.4.7",
     "lightweight-charts": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "jest __tests__ --watch"
   },
   "dependencies": {
-    "@radixdlt/radix-dapp-toolkit": "^0.7.1",
+    "@radixdlt/radix-dapp-toolkit": "^1.0.0",
     "@reduxjs/toolkit": "^1.9.5",
     "@types/node": "20.3.3",
     "@types/react": "18.2.14",


### PR DESCRIPTION
I've been using 0.10.1 on my local build and it works as expected generally. There are some intermittent issues, but I don't think that has to do with the DeXter dapp.