### PR TITLE
Navbar update to match figma

### DIFF
--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -1,16 +1,17 @@
 import React from "react";
 import Image from "next/image";
 import { FaRegMoon } from "react-icons/fa6";
+import Link from "next/link";
 
 // TODO: theme switching
 
 export function Navbar() {
   return (
-    <div className="col-span-12 navbar">
-      <div className="navbar-start">
-        <a
+    <div className="col-span-12 navbar p-0 min-h-6">
+      <div className="flex-none px-2 mx-2">
+        <Link
           href="/"
-          className="btn btn-ghost hover:bg-transparent no-underline text-xl p-0"
+          className="btn btn-ghost hover:bg-transparent no-underline text-xl p-0 join-item"
         >
           <Image
             src="/logo_icon.svg"
@@ -20,7 +21,29 @@ export function Navbar() {
             className="!my-0"
           />
           <span className="xs:invisible sm:visible uppercase">DeXter</span>
-        </a>
+        </Link>
+      </div>
+      <div className="flex-1 px-2 mx-2">
+        <div className="items-stretch hidden lg:flex">
+          <Link
+            className="btn btn-ghost hover:!no-underline pt-2 border-t-0 border-x-0 border-b-4 border-transparent hover:border-success hover:text-success uppercase"
+            href="/landing"
+          >
+            Landing
+          </Link>
+          <Link
+            className="btn btn-ghost hover:!no-underline pt-2 border-t-0 border-x-0 border-b-4 border-transparent hover:border-success hover:text-success uppercase"
+            href="/trade"
+          >
+            Trade
+          </Link>
+          <Link
+            className="btn btn-ghost hover:!no-underline pt-2 border-t-0 border-x-0 border-b-4 border-transparent hover:border-success hover:text-success uppercase"
+            href="/markets"
+          >
+            Markets
+          </Link>
+        </div>
       </div>
 
       <div className="navbar-end">

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import Image from "next/image";
-import { FaRegMoon } from "react-icons/fa6";
 import Link from "next/link";
 
 // TODO: theme switching

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -6,11 +6,11 @@ import Link from "next/link";
 
 export function Navbar() {
   return (
-    <div className="col-span-12 !py-0 navbar">
-      <div className="flex-none px-2 mx-2">
+    <div className="col-span-12 !py-0 px-3 navbar h-20">
+      <div className="flex-none">
         <Link
           href="/"
-          className="btn btn-ghost hover:bg-transparent no-underline text-xl p-0 join-item"
+          className="btn btn-ghost hover:bg-transparent no-underline hover:!no-underline text-xl join-item px-3"
         >
           <Image
             src="/logo_icon.svg"
@@ -19,26 +19,19 @@ export function Navbar() {
             height={40}
             className="!my-0"
           />
-          <span className="xs:invisible sm:visible uppercase">DeXter</span>
+          <span className="ml-6 pt-1 xs:invisible sm:visible hover:text-accent uppercase">DeXter</span>
         </Link>
       </div>
       <div className="flex-1 px-2 mx-2">
         <div className="items-stretch hidden lg:flex">
           <Link
-            className="btn btn-lg btn-ghost hover:!no-underline pt-2 border-t-0 border-x-0 border-b-4 border-transparent hover:border-accent hover:text-accent uppercase"
+            className="btn btn-lg h-20 btn-ghost hover:!no-underline pt-2 border-t-0 border-x-0 border-b-4 border-transparent hover:border-accent hover:text-accent uppercase"
             href="/"
           >
             Trade
           </Link>
-          <Link
-            className="btn btn-lg btn-ghost hover:!no-underline pt-2 border-t-0 border-x-0 border-b-4 border-transparent hover:border-accent hover:text-accent uppercase"
-            href="/markets"
-          >
-            Markets
-          </Link>
         </div>
       </div>
-
       <div className="navbar-end">
         <radix-connect-button></radix-connect-button>
       </div>

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 
 export function Navbar() {
   return (
-    <div className="col-span-12 navbar p-0 min-h-6">
+    <div className="col-span-12 !py-0 navbar">
       <div className="flex-none px-2 mx-2">
         <Link
           href="/"
@@ -26,19 +26,13 @@ export function Navbar() {
       <div className="flex-1 px-2 mx-2">
         <div className="items-stretch hidden lg:flex">
           <Link
-            className="btn btn-ghost hover:!no-underline pt-2 border-t-0 border-x-0 border-b-4 border-transparent hover:border-success hover:text-success uppercase"
-            href="/landing"
-          >
-            Landing
-          </Link>
-          <Link
-            className="btn btn-ghost hover:!no-underline pt-2 border-t-0 border-x-0 border-b-4 border-transparent hover:border-success hover:text-success uppercase"
-            href="/trade"
+            className="btn btn-lg btn-ghost hover:!no-underline pt-2 border-t-0 border-x-0 border-b-4 border-transparent hover:border-accent hover:text-accent uppercase"
+            href="/"
           >
             Trade
           </Link>
           <Link
-            className="btn btn-ghost hover:!no-underline pt-2 border-t-0 border-x-0 border-b-4 border-transparent hover:border-success hover:text-success uppercase"
+            className="btn btn-lg btn-ghost hover:!no-underline pt-2 border-t-0 border-x-0 border-b-4 border-transparent hover:border-accent hover:text-accent uppercase"
             href="/markets"
           >
             Markets

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -19,7 +19,9 @@ export function Navbar() {
             height={40}
             className="!my-0"
           />
-          <span className="ml-6 pt-1 xs:invisible sm:visible hover:text-accent uppercase">DeXter</span>
+          <span className="ml-6 pt-1 xs:invisible sm:visible hover:text-accent uppercase">
+            DeXter
+          </span>
         </Link>
       </div>
       <div className="flex-1 px-2 mx-2">

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -41,13 +41,6 @@ export function Navbar() {
       </div>
 
       <div className="navbar-end">
-        <div
-          className="btn mx-2 border-none"
-          style={{ height: "40px", minHeight: "40px" }}
-        >
-          <FaRegMoon className="h-6 w-6 text-secondary-content" />
-        </div>
-
         <radix-connect-button></radix-connect-button>
       </div>
     </div>

--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -1,0 +1,3 @@
+export default function Landing() {
+  return <div className="col-span-full p-4">Landing</div>;
+}

--- a/src/app/markets/page.tsx
+++ b/src/app/markets/page.tsx
@@ -1,0 +1,3 @@
+export default function Markets() {
+  return <div className="col-span-full p-4">Markets</div>;
+}

--- a/src/app/trade/page.tsx
+++ b/src/app/trade/page.tsx
@@ -1,0 +1,3 @@
+export default function Markets() {
+  return <div className="col-span-full p-4">Trade</div>;
+}


### PR DESCRIPTION
Fixes #133 

Colors need to be tweaked a bit and some padding polish, but I can do that after the first initial reviews on nav update to align figma.
![navbar refresh](https://github.com/DeXter-on-Radix/website/assets/3978285/1593a6bd-9aae-4005-8e1c-61f3b9720cd2)

Note:
Didn't change the default page.tsx that has the current trade page as I didn't want to disturb existing PR's
Placed some filler pages for Landing, Trade, Markets
Landing: We can remove this link and put it at the root, when everyone is ready
Trade: Future location of the trade page, placeholder for now
Markets: Mock out to match Figma
