### PR TITLE
Price info percent change calculation

### DIFF
--- a/src/app/redux/priceInfoSlice.ts
+++ b/src/app/redux/priceInfoSlice.ts
@@ -31,7 +31,10 @@ export const priceInfoSlice = createSlice({
       const currentPairInfo = action.payload.currentPairInfo;
       state.lastPrice = currentPairInfo.lastPrice;
       state.open24h = currentPairInfo.open24h;
-      state.change24h = currentPairInfo.change24h;
+      state.change24h =
+        ((currentPairInfo.lastPrice - currentPairInfo.open24h) /
+          currentPairInfo.open24h) *
+        100;
       state.high24h = currentPairInfo.high24h;
       state.low24h = currentPairInfo.low24h;
       state.value24h = currentPairInfo.value24h;


### PR DESCRIPTION
Fixes #129 
The number that is coming from the alphadex api, was strange so I did the calculation on our side with the alphadex open price.
Formula: ((last-open)/open)*100

Known Issues:
Floating point precision, sometimes there are 49.99999996 in the calculation. Potential fix was parseFloat(x).toPrecision(8), but this returns a string vs a number.