### PR TITLE
sdk version updated to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@types/node": "20.3.3",
         "@types/react": "18.2.14",
         "@types/react-dom": "18.2.6",
-        "alphadex-sdk-js": "^0.12.3",
+        "alphadex-sdk-js": "^0.12.4",
         "autoprefixer": "10.4.14",
         "eslint-config-next": "13.4.7",
         "lightweight-charts": "^4.0.1",
@@ -2332,9 +2332,9 @@
       }
     },
     "node_modules/alphadex-sdk-js": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/alphadex-sdk-js/-/alphadex-sdk-js-0.12.3.tgz",
-      "integrity": "sha512-RBtjG1BV+a/O6AgCs9Xba5kk+GHUOUcGP6XxzDcN4ZoBs3w8DwDulxpW4+QqIyOGbVqj0AVLWQSew2MHp/LXcA==",
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/alphadex-sdk-js/-/alphadex-sdk-js-0.12.4.tgz",
+      "integrity": "sha512-1H99ZAJp1CZlxc5k9REhuIHnaLsuhqv2cxnwFrPlEoKWU/LBhBfQJyk9Wa7wupo8F5aUV+N/Z9qlDrNDSTDUjg==",
       "dependencies": {
         "axios": "^1.3.2",
         "rxjs": "^7.8.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@types/node": "20.3.3",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",
-    "alphadex-sdk-js": "^0.12.3",
+    "alphadex-sdk-js": "^0.12.4",
     "autoprefixer": "10.4.14",
     "eslint-config-next": "13.4.7",
     "lightweight-charts": "^4.0.1",


### PR DESCRIPTION
This update is required as it contained a breaking change when connecting to the AlphaDEX backend. No further updates to dexter is required.