### PR TITLE
Fix price error message and display decimals in orderbook

### DIFF
--- a/src/app/components/OrderBook.tsx
+++ b/src/app/components/OrderBook.tsx
@@ -5,7 +5,13 @@ import * as utils from "../utils";
 import { OrderBookRowProps, orderBookSlice } from "../state/orderBookSlice";
 import { useAppDispatch, useAppSelector } from "../hooks";
 
-const N_DIGITS = 8;
+// For all intents, we can round all numbers to 8 decimals for Dexter.
+// Alphadex will not accept any numbers with more than 8 decimals
+// and it is doubtful whether people are that interested in numbers with more decimals.
+// https://discord.com/channels/1125689933735145503/1125689934251032584/1181882491464843314
+
+// 10 = for possible 8 decimals in smaller than 1 numbers + 1 for the decimal point + 1 for the leading 0
+const CHARACTERS_TO_DISPLAY = 10;
 
 function OrderBookRow(props: OrderBookRowProps) {
   const { barColor, orderCount, price, size, total, maxTotal } = props;
@@ -17,10 +23,9 @@ function OrderBookRow(props: OrderBookRowProps) {
     typeof total !== "undefined" &&
     typeof maxTotal !== "undefined"
   ) {
-    const charactersToDisplay = 6;
-    const priceString = utils.displayNumber(price, charactersToDisplay);
-    const sizeString = utils.displayNumber(size, charactersToDisplay);
-    const totalString = utils.displayNumber(total, charactersToDisplay);
+    const priceString = utils.displayNumber(price, CHARACTERS_TO_DISPLAY);
+    const sizeString = utils.displayNumber(size, CHARACTERS_TO_DISPLAY);
+    const totalString = utils.displayNumber(total, CHARACTERS_TO_DISPLAY);
     const barWidth = `${(total / maxTotal) * 100}%`;
 
     const barStyle = {
@@ -72,12 +77,12 @@ function CurrentPriceRow() {
     if (orderBook.spreadPercent !== null && orderBook.spread !== null) {
       const spread = utils.displayPositiveNumber(
         orderBook.spread,
-        N_DIGITS,
+        CHARACTERS_TO_DISPLAY,
         token2MaxDecimals
       );
       const spreadPercent = utils.displayPositiveNumber(
         orderBook.spreadPercent,
-        N_DIGITS,
+        CHARACTERS_TO_DISPLAY,
         2
       );
 

--- a/src/app/state/orderInputSlice.ts
+++ b/src/app/state/orderInputSlice.ts
@@ -21,6 +21,7 @@ export enum OrderTab {
 export enum ErrorMessage {
   UNSPECIFIED_PRICE = "Price must be specified",
   NONZERO_PRICE = "Price must be greater than 0",
+  NONZERO_AMOUNT = "Amount must be greater than 0",
   HIGH_PRICE = "Price is significantly higher than best sell",
   LOW_PRICE = "Price is significantly lower than best buy",
   EXCESSIVE_DECIMALS = "Too many decimal places",
@@ -628,7 +629,7 @@ function _validateAmount(amount: number | ""): ValidationResult {
 */
   if (amount <= 0) {
     valid = false;
-    message = ErrorMessage.NONZERO_PRICE;
+    message = ErrorMessage.NONZERO_AMOUNT;
   }
 
   return { valid, message };


### PR DESCRIPTION
fixes #187

This pull request fixes the error message for amount validation in the orderbook and ensures that decimals are displayed correctly.

## Before
<img width="1470" alt="Screenshot 2023-12-12 at 17 13 38" src="https://github.com/DeXter-on-Radix/website/assets/27793901/6525d343-4f7d-4afe-bddd-6adbe5ed79ea">


## After
<img width="1470" alt="Screenshot 2023-12-12 at 17 32 36" src="https://github.com/DeXter-on-Radix/website/assets/27793901/23c81a77-0786-4bd1-9952-c59be5dfb354">
