### PR TITLE
add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Assign the 'developers' team to review changes to any file
+* @DeXter-on-Radix/developers
+
+# End-to-end test directory can be reviewed by the 'testers' team
+/e2e/ @DeXter-on-Radix/testers

--- a/.prettierignore
+++ b/.prettierignore
@@ -45,3 +45,5 @@ next-env.d.ts
 
 localhost:3000/
 
+.github/CODEOWNERS
+


### PR DESCRIPTION
refs #23 

The CODEOWNERS file allows to set the following rule for approving PRs:
- PRs can be merged only after at least 1 code owner viewed the specified files ([developers team](https://github.com/orgs/DeXter-on-Radix/teams/developers for all files, [testers team](https://github.com/orgs/DeXter-on-Radix/teams/testers) for end to end tests 
- other people (repo/org owners, but not developers, e.g. `@Radstakes` ) will still be able to review and approve PRs and count as the second person 
- not specified in this file, but in github settings - we need at least 2 reviews per PR to be able to merge to `main`

<img width="768" alt="Screenshot 2024-01-16 at 11 28 18" src="https://github.com/DeXter-on-Radix/website/assets/27793901/3d1ec4e8-9162-41dd-af39-a9b93a8aab58">
