### PR TITLE
toString instead of toLocaleString

### DIFF
--- a/src/app/components/OrderBook.tsx
+++ b/src/app/components/OrderBook.tsx
@@ -61,19 +61,16 @@ function CurrentPriceRow() {
   );
 
   let spreadString = "";
+  let spreadValue = "";
 
   // checking for past trades here because adexState.currentPairInfo.lastPrice
   // is never null, and is = -1 if there were no trades
   let lastPrice = "";
   if (trades.length > 0) {
-    lastPrice = orderBook.lastPrice?.toString() || "";
-    //The full solution causes display issues as it will always display min digits
-    /*
-    lastPrice =
-      orderBook.lastPrice?.toLocaleString(undefined, {
-        minimumFractionDigits: token2MaxDecimals,
-      }) || "";
-      */
+    lastPrice = utils.displayNumber(
+      orderBook.lastPrice || 0,
+      CHARACTERS_TO_DISPLAY
+    );
   } else {
     lastPrice = "No trades have occurred yet";
   }
@@ -93,20 +90,22 @@ function CurrentPriceRow() {
         2
       );
 
-      spreadString = `${spread} (${spreadPercent}%)`;
+      spreadString = `(${spreadPercent}%)`;
+      spreadValue = `Spread ${spread}`;
     }
 
     return (
       <>
-        <div className="text-2xl text-accent text-left col-span-2 my-1 py-1 ml-2">
+        <div className="text-xl text-accent text-left col-span-2 my-1 py-1 ml-2">
           {lastPrice}
         </div>
 
-        <div className="flex text-accent justify-end col-span-2 text-sm my-1 py-1 whitespace-nowrap">
-          <span className="my-auto">Spread</span>{" "}
-          <span className="my-auto px-1 border-r-2 border-accent">
-            {spreadString}
-          </span>
+        <div className="flex text-accent justify-end items-center col-span-2 text-sm my-1 py-1 whitespace-nowrap">
+          <div className="tooltip tooltip-left" data-tip={spreadValue}>
+            <span className="my-auto px-1 border-r-2 border-accent">
+              {spreadString}
+            </span>
+          </div>
         </div>
       </>
     );

--- a/src/app/components/OrderBook.tsx
+++ b/src/app/components/OrderBook.tsx
@@ -90,7 +90,7 @@ function CurrentPriceRow() {
         2
       );
 
-      spreadString = `(${spreadPercent}%)`;
+      spreadString = `${spreadPercent}%`;
       spreadValue = `Spread ${spread}`;
     }
 

--- a/src/app/components/OrderBook.tsx
+++ b/src/app/components/OrderBook.tsx
@@ -66,7 +66,14 @@ function CurrentPriceRow() {
   // is never null, and is = -1 if there were no trades
   let lastPrice = "";
   if (trades.length > 0) {
-    lastPrice = orderBook.lastPrice?.toLocaleString() || "";
+    lastPrice = orderBook.lastPrice?.toString() || "";
+    //The full solution causes display issues as it will always display min digits
+    /*
+    lastPrice =
+      orderBook.lastPrice?.toLocaleString(undefined, {
+        minimumFractionDigits: token2MaxDecimals,
+      }) || "";
+      */
   } else {
     lastPrice = "No trades have occurred yet";
   }
@@ -105,7 +112,7 @@ function CurrentPriceRow() {
     );
   } else {
     return (
-      <div className="text-2xl text-left col-span-4  border-r-2 border-accent ml-2">
+      <div className="text-xl text-left col-span-4  border-r-2 border-accent ml-2">
         {lastPrice}
       </div>
     );


### PR DESCRIPTION
This is workaround to get correct decimals to display, as the toLocaleString solution causes issues with number display
For example: 
![image](https://github.com/DeXter-on-Radix/website/assets/3978285/d52d6230-38ba-4d8e-b8ee-e357a01b9bd9)
![image](https://github.com/DeXter-on-Radix/website/assets/3978285/2d63f777-fa08-4435-9c2d-08be49ad6103)

The problem is how Number and toLocaleString() loses precision. Example in dev console
![image](https://github.com/DeXter-on-Radix/website/assets/3978285/187aa7e7-1748-43c2-b544-b6a4ef981d2b)


