### PR TITLE
Set default candle period to 1D instead of 30m

### DIFF
--- a/src/app/state/priceChartSlice.ts
+++ b/src/app/state/priceChartSlice.ts
@@ -14,6 +14,7 @@ export interface OHLCVData extends CandlestickData {
 }
 
 // Candle periods from alphadex:
+// -> reference: https://www.npmjs.com/package/alphadex-sdk-js?activeTab=readme#candleperiods-array
 // -> ['5m', '15m', '30m', '1h', '4h', '6h', '12h', '1D', '1W', '1M']
 export const CANDLE_PERIODS = adex.CandlePeriods;
 
@@ -28,7 +29,7 @@ export interface PriceChartState {
 }
 
 const initialState: PriceChartState = {
-  candlePeriod: adex.CandlePeriods[7],  // default to 1D candle period
+  candlePeriod: adex.CandlePeriods[7],  // defaults to 1D candle period
   ohlcv: [],
   legendCandlePrice: null,
   legendPercChange: null,

--- a/src/app/state/priceChartSlice.ts
+++ b/src/app/state/priceChartSlice.ts
@@ -13,6 +13,8 @@ export interface OHLCVData extends CandlestickData {
   value: number;
 }
 
+// Candle periods from alphadex:
+// -> ['5m', '15m', '30m', '1h', '4h', '6h', '12h', '1D', '1W', '1M']
 export const CANDLE_PERIODS = adex.CandlePeriods;
 
 export interface PriceChartState {
@@ -26,7 +28,7 @@ export interface PriceChartState {
 }
 
 const initialState: PriceChartState = {
-  candlePeriod: adex.CandlePeriods[2],
+  candlePeriod: adex.CandlePeriods[7],  // default to 1D candle period
   ohlcv: [],
   legendCandlePrice: null,
   legendPercChange: null,


### PR DESCRIPTION
Given we currently have low liquidity, I suggest changing the default candle timeframe from 30m to 1D. Low liquidity chart might be off-putting and makes a bad first impression for new users IMO.

![change-default-timeframe-to-1D](https://github.com/DeXter-on-Radix/website/assets/44790691/37131fa1-dad7-47a5-bc52-22d3068710d1)
