### PR TITLE
Fix: Expand flex child to full height in trading panel

### DIFF
--- a/src/app/components/order_input/OrderInput.tsx
+++ b/src/app/components/order_input/OrderInput.tsx
@@ -66,7 +66,7 @@ export function OrderInput() {
   }, [dispatch, pairAddress]);
 
   return (
-    <div className="h-full flex flex-col text-base">
+    <div className="h-full w-full flex flex-col text-base">
       <OrderTypeTabs />
       {tab === OrderTab.LIMIT && <OrderSideTabs />}
       <div className="form-control justify-start flex-grow items-start bg-neutral p-4 w-full">

--- a/src/app/components/order_input/OrderInput.tsx
+++ b/src/app/components/order_input/OrderInput.tsx
@@ -66,7 +66,7 @@ export function OrderInput() {
   }, [dispatch, pairAddress]);
 
   return (
-    <div className="h-full w-full flex flex-col text-base">
+    <div className="h-full flex flex-col text-base">
       <OrderTypeTabs />
       {tab === OrderTab.LIMIT && <OrderSideTabs />}
       <div className="form-control justify-start flex-grow items-start bg-neutral p-4 w-full">

--- a/src/app/components/order_input/OrderInput.tsx
+++ b/src/app/components/order_input/OrderInput.tsx
@@ -66,10 +66,10 @@ export function OrderInput() {
   }, [dispatch, pairAddress]);
 
   return (
-    <div className="text-base">
+    <div className="h-full flex flex-col text-base">
       <OrderTypeTabs />
       {tab === OrderTab.LIMIT && <OrderSideTabs />}
-      <div className="form-control justify-between items-start bg-neutral p-4 w-full">
+      <div className="form-control justify-start flex-grow items-start bg-neutral p-4 w-full">
         {tab === OrderTab.MARKET ? <MarketOrderInput /> : <LimitOrderInput />}
         <SubmitButton />
         <div className="collapse collapse-arrow text-left">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,7 +45,7 @@ export default function Home() {
         <OrderBook />
       </div>
       <div className="grid grid-cols-12 xl:grid-cols-9 col-span-12 xl:col-span-9">
-        <div className="col-span-12 lg:col-span-5 xl:col-span-3 order-2 lg:order-1 text-center lg:border-r-4 border-base-300">
+        <div className="flex col-span-12 lg:col-span-5 xl:col-span-3 order-2 lg:order-1 text-center lg:border-r-4 border-base-300">
           <OrderInput />
         </div>
         <div className="col-span-12 p-2 lg:col-span-7 xl:col-span-6 order-1 lg:order-2 text-center xs:border-b-4 lg:border-b-0 border-base-300">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,7 +45,7 @@ export default function Home() {
         <OrderBook />
       </div>
       <div className="grid grid-cols-12 xl:grid-cols-9 col-span-12 xl:col-span-9">
-        <div className="flex col-span-12 lg:col-span-5 xl:col-span-3 order-2 lg:order-1 text-center lg:border-r-4 border-base-300">
+        <div className="col-span-12 lg:col-span-5 xl:col-span-3 order-2 lg:order-1 text-center lg:border-r-4 border-base-300">
           <OrderInput />
         </div>
         <div className="col-span-12 p-2 lg:col-span-7 xl:col-span-6 order-1 lg:order-2 text-center xs:border-b-4 lg:border-b-0 border-base-300">


### PR DESCRIPTION
This PR fixes the issue mentioned by @Kafkafrate, where the grey area should take up the full width of the panel:

![image](https://github.com/DeXter-on-Radix/website/assets/44790691/ac3e42f1-5d38-4bbf-ba7a-8ace3322b02a)

After: 
![Bildschirmfoto vom 2024-02-18 14-59-37](https://github.com/DeXter-on-Radix/website/assets/44790691/ada7a805-a0a4-427a-bd47-f0dee8c2eb96)
