### PR TITLE
remove nowrap and stack text vertically if not enough space

### DIFF
--- a/src/app/components/AccountHistory.tsx
+++ b/src/app/components/AccountHistory.tsx
@@ -17,7 +17,7 @@ function OrdersTabs() {
 
   function tabClass(isActive: boolean) {
     return (
-      "tab w-max no-underline h-full py-3 tab-border-1 uppercase" +
+      "tab w-max no-underline h-full py-3 tab-border-1 uppercase leading-4" +
       (isActive
         ? " tab-active tab-bordered text-accent-focus !border-accent"
         : "")
@@ -26,7 +26,7 @@ function OrdersTabs() {
 
   return (
     <div className="m-4">
-      <div className="tabs min-w-fit flex flex-nowrap space-x-4">
+      <div className="flex space-x-4">
         {tables.map((tableName) => (
           <div
             key={tableName}


### PR DESCRIPTION
Fixes #261 .

On small screens (e.g. mobile) the tabs section was causing an overflow bug. I suggest to wrap the text vertically with a narrow line height such that the tabs remain visible without the need to scroll. 

![fix-overflow-mobile-bug-orderhistory-](https://github.com/DeXter-on-Radix/website/assets/44790691/0881c563-d9c2-4db3-8882-4114df65fb58)
