### PR TITLE
improve pair selector component

### DIFF
--- a/public/chevron-down.svg
+++ b/public/chevron-down.svg
@@ -1,0 +1,4 @@
+<svg width="26" height="26" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="26" height="26" rx="2" fill="#1F2021"/>
+<path d="M12.6538 16.7077L7 11.0538L8.05383 10L12.6538 14.6L17.2538 10L18.3077 11.0538L12.6538 16.7077Z" fill="white"/>
+</svg>

--- a/src/app/components/PairSelector.tsx
+++ b/src/app/components/PairSelector.tsx
@@ -124,8 +124,6 @@ export function PairSelector() {
   }, [isOpen]);
 
   useEffect(() => {
-    // const newOptions = [];
-    // if (options.find(option => option["name"] === "xrd/"))
     const newOptions = options.filter(
       (option) => option["name"].toLowerCase().indexOf(query.toLowerCase()) > -1
     );


### PR DESCRIPTION
Fixes #223.

Improved the pair selector by:
- replacing slash `/` and magnifying glass with chevron (as designed by @Kafkafrate)
- removed margin and made hover state take up all width (as mentioned in #223)
- sorted the coins by following algorithm: XRD/xUSDC, DEXTR/XRD, (rest sorted alphabetically)
- added coin icon to dropdown and emphasized the first token, making the second token less prominent (inspired by Binance)
- added hover state (70% opacity -> 100%opcity on hover)

# Before
![Bildschirmfoto vom 2024-02-20 00-26-56](https://github.com/DeXter-on-Radix/website/assets/44790691/e60cf076-e388-4fa5-aa7d-6ae242590c6c)

# After
![Bildschirmfoto vom 2024-02-20 00-26-37](https://github.com/DeXter-on-Radix/website/assets/44790691/5f7454c2-fa9e-493f-bae0-1ef14f61a7a3)
