### PR TITLE
fix empty chart canvas

### DIFF
--- a/src/app/components/PriceChart.tsx
+++ b/src/app/components/PriceChart.tsx
@@ -169,6 +169,11 @@ function PriceChartCanvas(props: PriceChartProps) {
 
       window.addEventListener("resize", handleResize);
 
+      // Configure chart for full-canvas candle display. For reference: https://github.com/DeXter-on-Radix/website/issues/269
+      chart
+        .timeScale()
+        .setVisibleLogicalRange({ from: 0, to: clonedData.length });
+
       return () => {
         window.removeEventListener("resize", handleResize);
         chart.remove();


### PR DESCRIPTION
Fixes #269.

Just a proposal, I think it looks better when the candles are zoomed and real estate of the chart is fully used. 