### PR TITLE
temporarily remove navbar element

### DIFF
--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -25,14 +25,14 @@ export function Navbar() {
         </Link>
       </div>
       <div className="flex-1 px-2 mx-2">
-        <div className="items-stretch hidden lg:flex">
+        {/* <div className="items-stretch hidden lg:flex">
           <Link
             className="btn btn-lg h-20 btn-ghost hover:!no-underline pt-2 border-t-0 border-x-0 border-b-4 border-transparent hover:border-accent hover:text-accent uppercase"
             href="/"
           >
             Trade
           </Link>
-        </div>
+        </div> */}
       </div>
       <div className="navbar-end">
         <radix-connect-button></radix-connect-button>


### PR DESCRIPTION
I suggest temporarily removing the TRADE navbar element until we launch the landing page.


![inactive-nav-bar](https://github.com/DeXter-on-Radix/website/assets/44790691/4ab86ce1-9b0d-42f2-b062-26adbd3d59c0)
