### PR TITLE
Add env setup guide to contributors.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ NEXT_PUBLIC_DAPP_DEFINITION_ADDRESS=account_tdx_2_129kev9w27tsl7qjg0dlyze70kxnlz
 NEXT_PUBLIC_DEFAULT_PAIR_ADDRESS=component_tdx_2_1crs8ud8rr680krgtlskauye7qnns5zdawdlspvcqceder6tysu884p
 ```
 
-### Setup Testnet Wallet
+## Testnet Wallet Setup
 
 Follow these steps to configure your wallet for testnet use, enabling developer mode, switching networks, and acquiring test tokens.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,3 +42,28 @@ NEXT_PUBLIC_NETWORK=stokenet # Options: mainnet or stokenet
 NEXT_PUBLIC_DAPP_DEFINITION_ADDRESS=account_tdx_2_129kev9w27tsl7qjg0dlyze70kxnlzycs8v2c85kzec40gg8mt73f7y
 NEXT_PUBLIC_DEFAULT_PAIR_ADDRESS=component_tdx_2_1crs8ud8rr680krgtlskauye7qnns5zdawdlspvcqceder6tysu884p
 ```
+
+### Setup Testnet Wallet
+
+Follow these steps to configure your wallet for testnet use, enabling developer mode, switching networks, and acquiring test tokens.
+
+**Enable Developer Mode**
+
+1. **Access Settings**: Navigate to `App settings` from the main menu.
+2. **Activate Developer Mode**: Within `App settings`, locate and toggle on the `Developer Mode` option.
+
+**Switch to Testnet**
+
+1. **Open Gateways**: Within `App settings`, proceed to `Gateways`.
+2. **Select Testnet**: From the list of gateways, choose `babylon-stokenet-...` option.
+
+Your wallet is now in developer mode and connected to the testnet.
+
+**Acquire Test XRD Tokens**
+
+1. Follow the standard procedure to `Create a wallet` and set up a `Persona` within the app.
+2. **Access Test Account**: Open your test account profile.
+3. **Navigate to Dev Preferences**: Tap the three dots in the top right corner to access more options, then select `Dev preferences`.
+4. **Get Test Tokens**: Click on `Get XRD Test Tokens` to receive your test currency.
+
+By following these steps, you'll have your wallet set up for testing Dexter on localhost and creating orders using test XRD tokens.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,20 +25,20 @@ If you happen to use VS Code, install the recommended extensions to get automati
 
 ## Env setup
 
-By default `npm run dev` uses the testnet, but it can be set to mainnet by using a .env file in the root project dir with the following content:
+By default `npm run dev` uses the testnet (stokenet), but it can be set to mainnet by creating a `.env` file in the root project dir with the following content:
 
-### .env for testnet
-
-```
-NEXT_PUBLIC_NETWORK=stokenet # Options: mainnet or stokenet
-NEXT_PUBLIC_DAPP_DEFINITION_ADDRESS=account_tdx_2_129kev9w27tsl7qjg0dlyze70kxnlzycs8v2c85kzec40gg8mt73f7y
-NEXT_PUBLIC_DEFAULT_PAIR_ADDRESS=component_tdx_2_1crs8ud8rr680krgtlskauye7qnns5zdawdlspvcqceder6tysu884p
-```
-
-### .env for mainnet
+### mainnet
 
 ```
 NEXT_PUBLIC_NETWORK=mainnet # Options: mainnet or stokenet
 NEXT_PUBLIC_DAPP_DEFINITION_ADDRESS=account_rdx168qrzyngejus9nazhp7rw9z3qn2r7uk3ny89m5lwvl299ayv87vpn5
 NEXT_PUBLIC_DEFAULT_PAIR_ADDRESS=component_rdx1czgjmu4ed5hp0vn97ngsf6mevq9tl0v8rrh2yq0f4dnpndggk7j9pu
+```
+
+### testnet (default)
+
+```
+NEXT_PUBLIC_NETWORK=stokenet # Options: mainnet or stokenet
+NEXT_PUBLIC_DAPP_DEFINITION_ADDRESS=account_tdx_2_129kev9w27tsl7qjg0dlyze70kxnlzycs8v2c85kzec40gg8mt73f7y
+NEXT_PUBLIC_DEFAULT_PAIR_ADDRESS=component_tdx_2_1crs8ud8rr680krgtlskauye7qnns5zdawdlspvcqceder6tysu884p
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ If you happen to use VS Code, install the recommended extensions to get automati
 
 By default `npm run dev` uses the testnet (stokenet), but it can be set to mainnet by creating a `.env` file in the root project dir with the following content:
 
-### mainnet
+### Mainnet
 
 ```
 NEXT_PUBLIC_NETWORK=mainnet # Options: mainnet or stokenet
@@ -35,7 +35,7 @@ NEXT_PUBLIC_DAPP_DEFINITION_ADDRESS=account_rdx168qrzyngejus9nazhp7rw9z3qn2r7uk3
 NEXT_PUBLIC_DEFAULT_PAIR_ADDRESS=component_rdx1czgjmu4ed5hp0vn97ngsf6mevq9tl0v8rrh2yq0f4dnpndggk7j9pu
 ```
 
-### testnet (default)
+### Testnet (default)
 
 ```
 NEXT_PUBLIC_NETWORK=stokenet # Options: mainnet or stokenet

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,3 +22,23 @@ If you happen to use VS Code, install the recommended extensions to get automati
 - Make some changes.
 - Commit and push local branch changes to your own repo.
 - Make a pull request into the [original Dexter repo](https://github.com/DeXter-on-Radix/website).
+
+## Env setup
+
+By default `npm run dev` uses the testnet, but it can be set to mainnet by using a .env file in the root project dir with the following content:
+
+### .env for testnet
+
+```
+NEXT_PUBLIC_NETWORK=stokenet # Options: mainnet or stokenet
+NEXT_PUBLIC_DAPP_DEFINITION_ADDRESS=account_tdx_2_129kev9w27tsl7qjg0dlyze70kxnlzycs8v2c85kzec40gg8mt73f7y
+NEXT_PUBLIC_DEFAULT_PAIR_ADDRESS=component_tdx_2_1crs8ud8rr680krgtlskauye7qnns5zdawdlspvcqceder6tysu884p
+```
+
+### .env for mainnet
+
+```
+NEXT_PUBLIC_NETWORK=mainnet # Options: mainnet or stokenet
+NEXT_PUBLIC_DAPP_DEFINITION_ADDRESS=account_rdx168qrzyngejus9nazhp7rw9z3qn2r7uk3ny89m5lwvl299ayv87vpn5
+NEXT_PUBLIC_DEFAULT_PAIR_ADDRESS=component_rdx1czgjmu4ed5hp0vn97ngsf6mevq9tl0v8rrh2yq0f4dnpndggk7j9pu
+```


### PR DESCRIPTION
I got the information how to connect to mainnet or testnet from this comment:
https://github.com/DeXter-on-Radix/website/pull/255#issuecomment-1942186043

We should put it in the official documentation for reference.

Additionally I just got my local env to work and wanted to share the setup procedure for future contributors.