### PR TITLE
Fix trade history bug

### DIFF
--- a/src/app/components/DisplayTable.tsx
+++ b/src/app/components/DisplayTable.tsx
@@ -25,8 +25,8 @@ const headers = {
     "Order Type",
     "Direction",
     "Time Ordered",
-    "Order Price",
     "Amount",
+    "Order Price",
     "Filled Qty",
     "Completed %",
     "Action",
@@ -147,11 +147,11 @@ const OpenOrdersRows = ({ data }: TableProps) => {
         </td>
         <td>{displayTime(order.timeSubmitted, "full")}</td>
         <td>
-          {order.price} {getPriceSymbol(order)}
-        </td>
-        <td>
           {/* Amount */}
           {order.amount} {order.specifiedToken.symbol}
+        </td>
+        <td>
+          {order.price} {getPriceSymbol(order)}
         </td>
         <td>
           {/* Filled Qty (compute with completedPerc to avoid using amountFilled) */}

--- a/src/app/components/DisplayTable.tsx
+++ b/src/app/components/DisplayTable.tsx
@@ -147,7 +147,6 @@ const OpenOrdersRows = ({ data }: TableProps) => {
         </td>
         <td>{displayTime(order.timeSubmitted, "full")}</td>
         <td>
-          {/* Amount */}
           {order.amount} {order.specifiedToken.symbol}
         </td>
         <td>

--- a/src/app/components/DisplayTable.tsx
+++ b/src/app/components/DisplayTable.tsx
@@ -25,8 +25,8 @@ const headers = {
     "Order Type",
     "Direction",
     "Time Ordered",
-    "Amount",
     "Order Price",
+    "Amount",
     "Filled Qty",
     "Completed %",
     "Action",
@@ -147,13 +147,18 @@ const OpenOrdersRows = ({ data }: TableProps) => {
         </td>
         <td>{displayTime(order.timeSubmitted, "full")}</td>
         <td>
-          {order.amount} {order.specifiedToken.symbol}
-        </td>
-        <td>
           {order.price} {getPriceSymbol(order)}
         </td>
         <td>
-          {order.amountFilled} {order.specifiedToken.symbol}
+          {/* Amount */}
+          {order.amount} {order.specifiedToken.symbol}
+        </td>
+        <td>
+          {/* Filled Qty (compute with completedPerc to avoid using amountFilled) */}
+          {order.status === "COMPLETED"
+            ? order.amount
+            : (order.amount * order.completedPerc) / 100}{" "}
+          {order.specifiedToken.symbol}
         </td>
         <td>{order.completedPerc}%</td>
         <td>
@@ -179,9 +184,14 @@ const OrderHistoryRows = ({ data }: TableProps) => {
         </td>
         <td>{order.status}</td>
         <td>
-          {order.amountFilled} {order.specifiedToken.symbol}
+          {/* Filled Qty (computed with completedPerc to avoid using amountFilled) */}
+          {order.status === "COMPLETED"
+            ? order.amount
+            : (order.amount * order.completedPerc) / 100}{" "}
+          {order.specifiedToken.symbol}
         </td>
         <td>
+          {/* Order Qty */}
           {order.amount} {order.specifiedToken.symbol}
         </td>
         <td>
@@ -223,7 +233,8 @@ const TradeHistoryTable = ({ data }: TableProps) => {
           {getPriceSymbol(order)}
         </td>
         <td>
-          {order.amountFilled} {order.specifiedToken.symbol}
+          {/* Filled Qty (since the order is filled, the full amount was filled) */}
+          {order.amount} {order.specifiedToken.symbol}
         </td>
         <td>
           {calculateTotalFees(order)} {order.unclaimedToken.symbol}


### PR DESCRIPTION
Looking at @Kafkafrate screenshot (bugreport from telegram: https://t.me/dexter_discussion/12674):

![image](https://github.com/DeXter-on-Radix/website/assets/44790691/35233e3c-0f04-4ee3-9980-cc278bb75ca4)
![image](https://github.com/DeXter-on-Radix/website/assets/44790691/1dd64235-f5f7-4b22-b559-2ef82f2d0259)

First of all, if the order was filled 100% then "Filled qty" and "Order qty" should have the same quantity and token.

Given the price is 2 XRD, this means that 5XRD were paid to buy 2.5 DEXTR. This leads me to believe, that "Filed Qty" is refering to amount in DEXTR, while "Order Qty" is referring to amount in XRD. 

To ensure both coins are always the same, this PR calculates the "Filled Qty" from scratch, which should solve this inconsistency.

(side note: I have a suspicion that [`amountFilled`](https://socket.dev/npm/package/alphadex-sdk-js/files/0.12.9/lib/models/order-receipt.d.ts#L35) is not always specified in the same token as [`amount`](https://socket.dev/npm/package/alphadex-sdk-js/files/0.12.9/lib/models/order-receipt.d.ts#L28), can you confirm or deny @fliebenberg?)