### PR TITLE
update alphadex sdk to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/node": "20.3.3",
         "@types/react": "18.2.14",
         "@types/react-dom": "18.2.6",
-        "alphadex-sdk-js": "^0.12.9",
+        "alphadex-sdk-js": "^0.12.13",
         "autoprefixer": "10.4.14",
         "eslint-config-next": "13.4.7",
         "lightweight-charts": "^4.1.3",
@@ -2720,9 +2720,9 @@
       }
     },
     "node_modules/alphadex-sdk-js": {
-      "version": "0.12.9",
-      "resolved": "https://registry.npmjs.org/alphadex-sdk-js/-/alphadex-sdk-js-0.12.9.tgz",
-      "integrity": "sha512-AyC9zCWc5k7Pb+RoSCyz3W/iZpibiHKsl0gUMy9tUw4KkSriEbu4ArmlXOJeneKsrT3pzJHf3Ci7mksTmti8Ew==",
+      "version": "0.12.13",
+      "resolved": "https://registry.npmjs.org/alphadex-sdk-js/-/alphadex-sdk-js-0.12.13.tgz",
+      "integrity": "sha512-l57N4N93QtzkvoYWvAxjccvCp4HW0KD87CexVgPzn1VQTsquXneaT+ZUYg6IWLWa4I/rw6chQDIwJka5bT0Dcg==",
       "dependencies": {
         "axios": "^1.3.2",
         "rxjs": "^7.8.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@types/node": "20.3.3",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",
-    "alphadex-sdk-js": "^0.12.9",
+    "alphadex-sdk-js": "^0.12.13",
     "autoprefixer": "10.4.14",
     "eslint-config-next": "13.4.7",
     "lightweight-charts": "^4.1.3",


### PR DESCRIPTION
fixes #247 
refs #197 

Updated the alphadex sdk to the latest version. The new version fixes a bug where order details were not correctly updating sometimes (#247) and also allows for seamless switching between Alphadex API endpoints to avoid downtime when alphadex does api maintenance. Therefore this PR also partially addresses #197 as the SDK will now use either of the public Alphadex APIs.