### PR TITLE
fix unwanted element wrapping

### DIFF
--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -62,7 +62,7 @@ function LanguageSelection() {
   };
 
   return (
-    <div className="mr-4">
+    <div className="mr-4 flex">
       {supportedLanguages.map((lang) => (
         <button
           className={`uppercase text-sm px-1 ${


### PR DESCRIPTION
There was a bug where languages in the language selector (on small screens like mobiles) were perviously stacked instead of next to each other.

![Bildschirmfoto vom 2024-03-20 11-59-19](https://github.com/DeXter-on-Radix/website/assets/44790691/7bdfc7f1-3a58-4054-a5f9-62991bcaff48)

This PR fixes this.