### PR TITLE
Add toaster notifications (for submit order + cancel order)

### DIFF
--- a/src/app/components/DisplayTable.tsx
+++ b/src/app/components/DisplayTable.tsx
@@ -71,27 +71,29 @@ function ActionButton({
       <button
         onClick={async (e) => {
           e.stopPropagation();
-          // Execute DexterToast.promise with the provided success and failure messages
           DexterToast.promise(
+            // Function input, with following state-to-toast mapping
+            // -> pending: loading toast
+            // -> rejceted: error toast
+            // -> resolved: success toast
             async () => {
-              // Await the dispatch and result of the cancelOrder action
               const action = await dispatch(
                 cancelOrder({
                   orderId: order.id,
                   pairAddress: order.pairAddress,
                 })
               );
-              // Transaction was not fulfilled (e.g. userRejected or userCanceled)
               if (!action.type.endsWith("fulfilled")) {
+                // Transaction was not fulfilled (e.g. userRejected or userCanceled)
                 throw new Error("Transaction failed due to user action.");
-                // Transaction was fulfilled but failed (e.g. submitted onchain failure)
               } else if ((action.payload as any)?.status === "ERROR") {
+                // Transaction was fulfilled but failed (e.g. submitted onchain failure)
                 throw new Error("Transaction failed onledger");
               }
-            }, // Since the action is now performed, we resolve the promise immediately
-            "Cancelling order",
-            "Order cancelled",
-            "Failed to cancel order"
+            },
+            t("cancelling_order"), // Loading message
+            t("order_cancelled"), // success message
+            t("failed_to_cancel_order") // error message
           );
         }}
         className="text-error hover:underline transition"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { store } from "./state/store";
 import { Provider } from "react-redux";
 import { usePathname } from "next/navigation";
 import { DexterToaster } from "./components/DexterToaster";
+import { detectOperatingSystem } from "utils";
 
 export default function RootLayout({
   children,
@@ -16,6 +17,14 @@ export default function RootLayout({
 }) {
   const path = usePathname();
 
+  const os = detectOperatingSystem();
+  console.log({ os });
+  const toastPosition = {
+    WINDOWS: "bottom-center",
+    MAC: "top-center",
+    LINUX: "top-center",
+    UNKNOWN: "top-center",
+  }[os];
   // TODO: after MVP remove "use client", fix all as many Components as possible
   // to be server components for better SSG and SEO
   // and use metadata https://nextjs.org/docs/app/building-your-application/upgrading/app-router-migration#step-2-creating-a-root-layout
@@ -27,7 +36,7 @@ export default function RootLayout({
       </head>
       <Provider store={store}>
         <body>
-          <DexterToaster toastPosition="bottom-right" />
+          <DexterToaster toastPosition={toastPosition} />
           <div
             data-path={path}
             className="h-screen prose md:prose-lg lg:prose-xl max-w-none flex flex-col"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,7 +18,6 @@ export default function RootLayout({
   const path = usePathname();
 
   const os = detectOperatingSystem();
-  console.log({ os });
   const toastPosition = {
     WINDOWS: "bottom-center",
     MAC: "top-center",

--- a/src/app/state/locales/en/trade.json
+++ b/src/app/state/locales/en/trade.json
@@ -67,5 +67,11 @@
   "no_trades_have_occured_yet": "No trades have occurred yet",
   "market_action_token": "<$ORDER_TYPE> <$SIDE> <$TOKEN_SYMBOL>",
   "at_max_price": "At Max Price",
-  "at_min_price": "At Min Price"
+  "at_min_price": "At Min Price",
+  "cancelling_order": "Cancelling order...",
+  "order_cancelled": "Order cancelled",
+  "failed_to_cancel_order": "Failed to cancel order",
+  "submitting_order": "Submitting order...",
+  "order_submitted": "Order submitted",
+  "failed_to_submit_order": "Failed to submit order"
 }

--- a/src/app/state/locales/pt/trade.json
+++ b/src/app/state/locales/pt/trade.json
@@ -67,5 +67,11 @@
   "no_trades_have_occured_yet": "Nenhuma transação foi realizada ainda",
   "market_action_token": "<$SIDE> <$TOKEN_SYMBOL> a <$ORDER_TYPE>",
   "at_max_price": "Preço Máximo",
-  "at_min_price": "Preço Mínimo"
+  "at_min_price": "Preço Mínimo",
+  "cancelling_order": "Cancelando ordem...",
+  "order_cancelled": "Ordem cancelada",
+  "failed_to_cancel_order": "Falha ao cancelar ordem",
+  "submitting_order": "Enviando ordem...",
+  "order_submitted": "Ordem enviada",
+  "failed_to_submit_order": "Falha ao enviar ordem"
 }

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -346,3 +346,28 @@ export function detectBrowserLanguage(defaultLanguage: string = "en"): string {
   // Fallback to a default language if none is detected
   return defaultLanguage;
 }
+
+// Define an enum for the operating system types
+export enum OperatingSystem {
+  MAC = "MAC",
+  WINDOWS = "WINDOWS",
+  LINUX = "LINUX",
+  UNKNOWN = "UNKNOWN",
+}
+
+// Function to detect the users operating system based on navigator
+export function detectOperatingSystem(): OperatingSystem {
+  if (typeof window === "undefined" || typeof navigator === "undefined") {
+    return OperatingSystem.UNKNOWN;
+  }
+  const userAgent = navigator.userAgent.toLowerCase();
+  if (userAgent.includes("mac os")) {
+    return OperatingSystem.MAC;
+  } else if (userAgent.includes("windows")) {
+    return OperatingSystem.WINDOWS;
+  } else if (userAgent.includes("linux")) {
+    return OperatingSystem.LINUX;
+  } else {
+    return OperatingSystem.UNKNOWN;
+  }
+}


### PR DESCRIPTION
Implemented toast notifications for the following user actions:
- submit order (market or limit)
- cancel order

The toast is waiting in a loading state, until the user either accepts or rejects the transaction in the wallet app. 