### PR TITLE
fix routing on github pages

### DIFF
--- a/.github/workflows/stokenet-deploy-main.yml
+++ b/.github/workflows/stokenet-deploy-main.yml
@@ -53,14 +53,16 @@ jobs:
         with:
           node-version: "20"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
+      # - name: Setup Pages
+      #   uses: actions/configure-pages@v4
+      #   with:
+      #     # Automatically inject basePath in your Next.js configuration file and disable
+      #     # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
+      #     #
+      #     # You may remove this line if you want to manage the configuration yourself.
+      #     static_site_generator: next
       - name: Setup Pages
-        uses: actions/configure-pages@v4
-        with:
-          # Automatically inject basePath in your Next.js configuration file and disable
-          # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
-          #
-          # You may remove this line if you want to manage the configuration yourself.
-          static_site_generator: next
+        run: echo "BASE_PATH=/${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
       - name: Restore cache
         uses: actions/cache@v4
         with:

--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,9 @@ const nextConfig = {
   reactStrictMode: false,
 
   pageExtensions: ["js", "jsx", "mdx", "ts", "tsx"],
+
+  // for github pages
+  basePath: process.env.BASE_PATH || "",
 };
 
 module.exports = withMDX(nextConfig);


### PR DESCRIPTION
Tried out in [my fork](https://evgeniiavak.github.io/dexter-website/) (should have done it with the last 2 PRs as well ☺️ ) - now it should work 💯%

Previous GitHub deployment fix worked but the result was still broken, only html was accessible, styles and scripts - not:

<img width="668" alt="Screenshot 2024-04-03 at 21 00 54" src="https://github.com/DeXter-on-Radix/website/assets/27793901/b0fa44c3-11d8-4f56-9341-d6f929d0d1ed">


