### PR TITLE
fix pair component missing unique key bug

### DIFF
--- a/src/app/components/PairSelector.tsx
+++ b/src/app/components/PairSelector.tsx
@@ -190,7 +190,7 @@ export function PairSelector() {
           const [pair1, pair2] = getPairs(option["name"]);
 
           return (
-            <React.Fragment key={`fragment-${index}`}>
+            <React.Fragment key={`pair-${index}`}>
               {index === 0 && (
                 <div className="flex justify-between text-sm opacity-40 ml-3 mr-3">
                   <span className="uppercase">{t("pairs")}</span>

--- a/src/app/components/PairSelector.tsx
+++ b/src/app/components/PairSelector.tsx
@@ -4,6 +4,7 @@ import { orderInputSlice } from "../state/orderInputSlice";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FaSearch } from "react-icons/fa";
 import Image from "next/image";
+import React from "react";
 
 interface PairInfo {
   name: string;
@@ -189,7 +190,7 @@ export function PairSelector() {
           const [pair1, pair2] = getPairs(option["name"]);
 
           return (
-            <>
+            <React.Fragment key={`fragment-${index}`}>
               {index === 0 && (
                 <div className="flex justify-between text-sm opacity-40 ml-3 mr-3">
                   <span className="uppercase">{t("pairs")}</span>
@@ -232,7 +233,7 @@ export function PairSelector() {
                   </div>
                 </div>
               </li>
-            </>
+            </React.Fragment>
           );
         })}
         <li


### PR DESCRIPTION
Nothing major, but having unique keys specified for each elements in a loop improves performance. 

![image](https://github.com/DeXter-on-Radix/website/assets/44790691/6f2072cf-16cc-4204-967c-51dee50dae8a)


I'm surprised that next lets us export the app with this error, I believe it would be better to block deployment in such a case, WDYT @EvgeniiaVak?

