### PR TITLE
preload logo

### DIFF
--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -26,6 +26,7 @@ export function Navbar() {
             width={40}
             height={40}
             className="!my-0"
+            priority={true}
           />
           <span className="ml-6 pt-1 xs:invisible sm:visible hover:text-accent uppercase">
             DeXter


### PR DESCRIPTION
This PR removes the following warning from the console. 

![image](https://github.com/DeXter-on-Radix/website/assets/44790691/f3fc30f6-6118-473a-9578-811c6fa71a0c)

I tested with lighthouse but our loading state is so long (1900ms), that this improvement is very marginal and not noticable. We can debate whether it makes sense to merge or not.
