### PR TITLE
handle isConnected state

### DIFF
--- a/src/app/state/radixSlice.ts
+++ b/src/app/state/radixSlice.ts
@@ -16,7 +16,6 @@ const initialState: RadixState = {
     personaData: [],
     proofs: [],
   },
-  // TODO: handle connection status
   isConnected: false,
 };
 
@@ -27,6 +26,7 @@ export const radixSlice = createSlice({
   // synchronous reducers
   reducers: {
     setWalletData: (state: RadixState, action: PayloadAction<WalletData>) => {
+      state.isConnected = action.payload.accounts.length > 0;
       state.walletData = action.payload;
     },
   },


### PR DESCRIPTION
This PR adds the users login status (logged in vs not logged in) to the radix slice, which is a useful feature currently needed for the rewards page.

Its a very simple change so I am a wondering why it was postponed and marked as TODO in the first place @EvgeniiaVak , am I missing some issues here?