### PR TITLE
push footer down if there is no content

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,9 +32,11 @@ export default function RootLayout({
             data-path={path}
             className="h-screen prose md:prose-lg lg:prose-xl max-w-none flex flex-col"
           >
-            <Navbar />
-            {children}
-            <Footer />
+            <div className="flex flex-col justify-between min-h-[100vh]">
+              <Navbar />
+              {children}
+              <Footer />
+            </div>
           </div>
         </body>
       </Provider>


### PR DESCRIPTION
When there is a page with less content than 100vh, the footer currently is glitching. This PR pushes the footer down such that it is at the bottom, even if there is no content. 
![image](https://github.com/DeXter-on-Radix/website/assets/44790691/936af2a5-7872-4e59-828f-65bf06e49a75)

## To Reproduce

- go to https://dexteronradix.com
- open devtools and run the following command inside the console:
```js
document.querySelector(".flex-grow.grid.grid-cols-12.custom-auto-row-grids.max-w-none.divide-y-4.divide-base-300").remove()
``` 
- this should give you the "BEFORE" result (left image)
- then run the same command inside the deploy-preview, which should give you the "AFTER" result (right image)
