### PR TITLE
prevent 3rd party tracking by cookie

### DIFF
--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -59,7 +59,7 @@ function LanguageSelection() {
 
   const handleLanguageChange = (lang: string) => {
     dispatch(i18nSlice.actions.changeLanguage(lang.toLowerCase()));
-    Cookies.set("userLanguage", lang, { expires: 365 }); // Set a cookie for 1 year
+    Cookies.set("userLanguage", lang, { expires: 365, partitioned: true }); // Set a cookie for 1 year
   };
 
   return (


### PR DESCRIPTION
This should fix #342 . 

More context: 
having `partitioned: true` makes the cookie have a separated partition storage, meaning tracking of cookies througout multiple sites is not possible anymore (CHIPS -> cookie having independant partitioned state). 

More information here:
https://developers.google.com/privacy-sandbox/3pcd/chips
https://youtu.be/zYp0DFFmGxk?si=5R8jzweBgrGP2Tsy

It's one way that google chrome suggests to solve the tracking cookie problem.
