### PR TITLE
[ENHANCEMENT] Improve trade history

### DIFF
--- a/src/app/components/DisplayTable.tsx
+++ b/src/app/components/DisplayTable.tsx
@@ -10,7 +10,7 @@ import {
 import {
   cancelOrder,
   selectOpenOrders,
-  selectTradeHistory,
+  selectOrderHistory,
 } from "../state/accountHistorySlice";
 import { AccountHistoryState, Tables } from "../state/accountHistorySlice";
 interface TableProps {
@@ -46,15 +46,6 @@ const headers = {
     "order_fee",
     "time_ordered",
     "action",
-  ],
-  [Tables.TRADE_HISTORY]: [
-    "pair",
-    "direction",
-    "order_price",
-    "avg_filled_price",
-    "filled_qty",
-    "order_fee",
-    "time_completed",
   ],
 };
 
@@ -111,10 +102,7 @@ export function DisplayTable() {
     (state) => state.accountHistory.selectedTable
   );
   const openOrders = useAppSelector(selectOpenOrders);
-  const orderHistory = useAppSelector(
-    (state) => state.accountHistory.orderHistory
-  );
-  const tradeHistory = useAppSelector(selectTradeHistory);
+  const orderHistory = useAppSelector(selectOrderHistory);
 
   const tableToShow = useMemo(() => {
     switch (selectedTable) {
@@ -130,19 +118,13 @@ export function DisplayTable() {
           rows: <OrderHistoryRows data={orderHistory} />,
         };
 
-      case Tables.TRADE_HISTORY:
-        return {
-          headers: headers[Tables.TRADE_HISTORY],
-          rows: <TradeHistoryTable data={tradeHistory} />,
-        };
-
       default:
         return {
           headers: [],
           rows: <></>,
         };
     }
-  }, [openOrders, orderHistory, selectedTable, tradeHistory]);
+  }, [openOrders, orderHistory, selectedTable]);
 
   return (
     <div className="overflow-x-auto">
@@ -240,39 +222,6 @@ const OrderHistoryRows = ({ data }: TableProps) => {
   ) : (
     <tr>
       <td colSpan={7}>{t("no_order_history")}</td>
-    </tr>
-  );
-};
-
-const TradeHistoryTable = ({ data }: TableProps) => {
-  const t = useTranslations();
-  return data.length ? (
-    data.map((order) => (
-      <tr key={order.id} className="">
-        <td>{order.pairName}</td>
-        <td className={displayOrderSide(order.side).className}>
-          {t(displayOrderSide(order.side).text)}
-        </td>
-        <td>
-          {order.price} {getPriceSymbol(order)}
-        </td>
-        <td>
-          {calculateAvgFilled(order.token1Filled, order.token2Filled)}{" "}
-          {getPriceSymbol(order)}
-        </td>
-        <td>
-          {/* Filled Qty (since the order is filled, the full amount was filled) */}
-          {order.amount} {order.specifiedToken.symbol}
-        </td>
-        <td>
-          {calculateTotalFees(order)} {order.unclaimedToken.symbol}
-        </td>
-        <td>{displayTime(order.timeCompleted, "full")}</td>
-      </tr>
-    ))
-  ) : (
-    <tr>
-      <td colSpan={7}>{t("no_trade_history")}</td>
     </tr>
   );
 };

--- a/src/app/components/DisplayTable.tsx
+++ b/src/app/components/DisplayTable.tsx
@@ -45,7 +45,6 @@ const headers = {
     "order_price",
     "order_fee",
     "time_ordered",
-    "action",
   ],
 };
 
@@ -214,9 +213,6 @@ const OrderHistoryRows = ({ data }: TableProps) => {
           {calculateTotalFees(order)} {order.unclaimedToken.symbol}
         </td>
         <td>{displayTime(order.timeSubmitted, "full")}</td>
-        <td>
-          <ActionButton order={order} />
-        </td>
       </tr>
     ))
   ) : (

--- a/src/app/components/DisplayTable.tsx
+++ b/src/app/components/DisplayTable.tsx
@@ -184,7 +184,14 @@ const OrderHistoryRows = ({ data }: TableProps) => {
   const t = useTranslations();
   return data.length ? (
     data.map((order) => (
-      <tr key={order.id} className="">
+      <tr
+        key={order.id}
+        className={
+          order.status === "CANCELLED" && order.completedPerc === 0
+            ? "opacity-30"
+            : ""
+        }
+      >
         <td>{order.pairName}</td>
         <td className="uppercase">{t(order.orderType)}</td>
         <td className={displayOrderSide(order.side).className}>

--- a/src/app/state/accountHistorySlice.ts
+++ b/src/app/state/accountHistorySlice.ts
@@ -13,7 +13,6 @@ import { getRdt, RDT } from "../subscriptions";
 export enum Tables {
   OPEN_ORDERS = "OPEN_ORDERS",
   ORDER_HISTORY = "ORDER_HISTORY",
-  TRADE_HISTORY = "TRADE_HISTORY",
 }
 export interface AccountHistoryState {
   trades: adex.Trade[];
@@ -128,6 +127,7 @@ export const accountHistorySlice = createSlice({
 // SELECTORS
 export const { setSelectedTable } = accountHistorySlice.actions;
 
+// TODO: possibly remove, as this selector seems to not be used anywhere in the code
 export const selectFilteredData = createSelector(
   (state: RootState) => state.accountHistory.orderHistory,
   (state: RootState) => state.accountHistory.selectedTable,
@@ -137,8 +137,6 @@ export const selectFilteredData = createSelector(
         return orderHistory.filter((order) => order.status === "PENDING");
       case Tables.ORDER_HISTORY:
         return orderHistory;
-      case Tables.TRADE_HISTORY:
-        return orderHistory.filter((order) => order.status === "COMPLETED");
       default:
         return orderHistory;
     }
@@ -150,9 +148,9 @@ export const selectOpenOrders = createSelector(
   (orderHistory) => orderHistory.filter((order) => order.status === "PENDING")
 );
 
-export const selectTradeHistory = createSelector(
+export const selectOrderHistory = createSelector(
   (state: RootState) => state.accountHistory.orderHistory,
-  (orderHistory) => orderHistory.filter((order) => order.status === "COMPLETED")
+  (orderHistory) => orderHistory.filter((order) => order.status !== "PENDING")
 );
 
 export const selectTables = (state: RootState) => state.accountHistory.tables;

--- a/src/app/state/locales/en/enums.json
+++ b/src/app/state/locales/en/enums.json
@@ -4,7 +4,7 @@
   "BUY": "Buy",
   "SELL": "Sell",
   "PENDING": "Pending",
-  "COMPLETED": "Completed",
+  "COMPLETED": "Filled",
   "CANCELLED": "Cancelled",
   "POSTONLY": "Post Only",
   "MARKETPARTIAL": "Market (Partial)",

--- a/src/app/state/locales/pt/enums.json
+++ b/src/app/state/locales/pt/enums.json
@@ -4,7 +4,7 @@
   "BUY": "Comprar",
   "SELL": "Vender",
   "PENDING": "Pendente",
-  "COMPLETED": "Concluído",
+  "COMPLETED": "Executado",
   "CANCELLED": "Cancelado",
   "POSTONLY": "Apenas Postagem",
   "MARKETPARTIAL": "Mercado (Parcial)",


### PR DESCRIPTION
We currently have 2 problems:
1. TradeHistory provides no additional information compared to OrderHistory
2. OrderHistory also contains Open Orders, which is unexpected and confusing

**My suggestion** 
- remove tradeHistory for now
- Open Order should only show orders that are pending
- Order History shouly only show orders that are either cancelled or fulfilled. Pending orders are not history.
  
### Here is a recap of all changes:
- restructured to only contain "OpenOrders" and "OrderHistory"
- removed "action" from OrderHistory, as order history now represents final state

(Additional changes / enhancements)
- replaced "COMPLETED" with "FILLED" as its more clear to the user
- de-emphasized cancelled rows by adding opacity, inspired by binance
  
![image](https://github.com/DeXter-on-Radix/website/assets/44790691/0634fe9d-b887-47d4-86f0-b2b2ca2bdec7)


NOTE: we should still implement "Trade Hisotry", but in a correct way, see #367 for more information.
