### PR TITLE
move store one layer up to layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,16 +4,26 @@ import "./styles/globals.css";
 
 import { Footer } from "./components/Footer";
 import { Navbar } from "./components/NavBar";
-import { store } from "./state/store";
 import { Provider } from "react-redux";
 import { usePathname } from "next/navigation";
 import { DexterToaster } from "./components/DexterToaster";
+import { useEffect } from "react";
+import { initializeSubscriptions, unsubscribeAll } from "./subscriptions";
+import { store } from "./state/store";
 
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  // Initialize store
+  useEffect(() => {
+    initializeSubscriptions(store);
+    return () => {
+      unsubscribeAll();
+    };
+  }, []);
+
   const path = usePathname();
 
   // TODO: after MVP remove "use client", fix all as many Components as possible

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,8 +11,6 @@ import { PriceInfo } from "components/PriceInfo";
 import { fetchBalances } from "state/pairSelectorSlice";
 import { useAppDispatch, useAppSelector } from "hooks";
 import { fetchAccountHistory } from "state/accountHistorySlice";
-import { initializeSubscriptions, unsubscribeAll } from "./subscriptions";
-import { store } from "./state/store";
 
 import { detectBrowserLanguage } from "./utils";
 import { i18nSlice } from "./state/i18nSlice";
@@ -47,13 +45,6 @@ export default function Home() {
       dispatch(i18nSlice.actions.changeLanguage(detectBrowserLanguage()));
     }
   }, [dispatch]);
-
-  useEffect(() => {
-    initializeSubscriptions(store);
-    return () => {
-      unsubscribeAll();
-    };
-  }, []);
 
   useEffect(() => {
     const intervalId = setInterval(() => {

--- a/src/app/rewards/page.tsx
+++ b/src/app/rewards/page.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { initializeSubscriptions, unsubscribeAll } from "../subscriptions";
-import { store } from "../state/store";
 import { useAppDispatch, useAppSelector, useTranslations } from "hooks";
 import {
   fetchAddresses,
@@ -21,13 +19,6 @@ import { getTokenRewards, getTypeRewards } from "../state/rewardUtils";
 import { DexterToast } from "../components/DexterToaster";
 
 export default function Rewards() {
-  useEffect(() => {
-    initializeSubscriptions(store);
-    return () => {
-      unsubscribeAll();
-    };
-  }, []);
-
   const { showSuccessUi } = useAppSelector((state) => state.rewardSlice);
   return (
     <div className="bg-[#141414]">


### PR DESCRIPTION
Move the store initialization one layer up to `Layout.tsx` to prevent duplicate store initializations.

Fixes requested change from @EvgeniiaVak : [LINK](https://github.com/DeXter-on-Radix/website/pull/312/files#r1559880353)