### PR TITLE
fixed get orders more than 100 bug

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 Contributions are welcome!
-1
+
 Check out [existing issues (especially Todo)](https://github.com/orgs/DeXter-on-Radix/projects/1/views/1), review a [pull request](https://github.com/orgs/DeXter-on-Radix/projects/1/views/3), or [create a new issue](https://github.com/DeXter-on-Radix/website/issues/new) to start a discussion.
 
 Here are a few guidelines to follow:

--- a/src/app/state/rewardUtils.tsx
+++ b/src/app/state/rewardUtils.tsx
@@ -298,7 +298,7 @@ export async function getOrderRewards(
   let result: OrderRewards[] = [];
   const rdt = getRdtOrThrow();
   // console.log("Getting OrderRewards for receiptIds: ", receiptIds);
-  const maxBatchSize = 100;
+  const maxBatchSize = 90;
   let batchStart = 0;
   do {
     let batchReceiptIds = receiptIds.slice(


### PR DESCRIPTION
Quick fix for bug when trying to fetch 100 or more orders. Have just reduced the maximum per fetch to 90, which should fix the issue.