### PR TITLE
Fix precision issue

### DIFF
--- a/src/app/components/OrderInput.tsx
+++ b/src/app/components/OrderInput.tsx
@@ -544,10 +544,11 @@ function CurrencyInputGroupSettings(
       isXRD ? balanceToken1 - XRD_FEE_ALLOWANCE : balanceToken1,
       Calculator.divide(Calculator.multiply(balanceToken1, percentage), 100)
     );
-    const targetAmountRounded = truncateWithPrecision(targetAmount, 8);
+    // TODO: revert truncating to 8th decimal once adex has fixed adex.createExchangeOrderTx bug
+    const targetAmountTruncated = truncateWithPrecision(targetAmount, 8);
     dispatch(
       orderInputSlice.actions.setTokenAmount({
-        amount: targetAmountRounded,
+        amount: targetAmountTruncated,
         bestBuy,
         bestSell,
         balanceToken1: balanceToken1,
@@ -568,10 +569,11 @@ function CurrencyInputGroupSettings(
       isXRD ? balanceToken2 - XRD_FEE_ALLOWANCE : balanceToken2,
       Calculator.divide(Calculator.multiply(balanceToken2, percentage), 100)
     );
-    const targetAmountRounded = truncateWithPrecision(targetAmount, 8);
+    // TODO: revert truncating to 8th decimal once adex has fixed adex.createExchangeOrderTx bug
+    const targetAmountTruncated = truncateWithPrecision(targetAmount, 8);
     dispatch(
       orderInputSlice.actions.setTokenAmount({
-        amount: targetAmountRounded,
+        amount: targetAmountTruncated,
         bestBuy,
         bestSell,
         balanceToken1: balanceToken1,

--- a/src/app/components/OrderInput.tsx
+++ b/src/app/components/OrderInput.tsx
@@ -253,7 +253,7 @@ function EstimatedTotalOrQuantity() {
         <>
           <p className="grow text-left">Total:</p>
           <p className="">
-            ~ {amount.toFixed(2)} {symbol}
+            ~ {truncateWithPrecision(amount, 2)} {symbol}
           </p>
           <InfoTooltip content={quoteDescription} />
         </>
@@ -542,7 +542,10 @@ function CurrencyInputGroupSettings(
     }
     const targetAmount = Math.min(
       isXRD ? balanceToken1 - XRD_FEE_ALLOWANCE : balanceToken1,
-      Calculator.divide(Calculator.multiply(balanceToken1, percentage), 100)
+      Calculator.divide(
+        Calculator.multiply(balanceToken1, percentage - 0.001),
+        100
+      )
     );
     dispatch(
       orderInputSlice.actions.setTokenAmount({
@@ -565,7 +568,10 @@ function CurrencyInputGroupSettings(
     }
     const targetAmount = Math.min(
       isXRD ? balanceToken2 - XRD_FEE_ALLOWANCE : balanceToken2,
-      Calculator.divide(Calculator.multiply(balanceToken2, percentage), 100)
+      Calculator.divide(
+        Calculator.multiply(balanceToken2, percentage - 0.001),
+        100
+      )
     );
     dispatch(
       orderInputSlice.actions.setTokenAmount({
@@ -727,7 +733,8 @@ function SecondaryLabel({
           : () => {}
       }
     >
-      {label}: {value === 0 ? 0 : value.toFixed(getPrecision(currency))}{" "}
+      {label}:{" "}
+      {value === 0 ? 0 : truncateWithPrecision(value, getPrecision(currency))}{" "}
       {currency}
     </p>
   );

--- a/src/app/components/OrderInput.tsx
+++ b/src/app/components/OrderInput.tsx
@@ -542,14 +542,12 @@ function CurrencyInputGroupSettings(
     }
     const targetAmount = Math.min(
       isXRD ? balanceToken1 - XRD_FEE_ALLOWANCE : balanceToken1,
-      Calculator.divide(
-        Calculator.multiply(balanceToken1, percentage - 0.001),
-        100
-      )
+      Calculator.divide(Calculator.multiply(balanceToken1, percentage), 100)
     );
+    const targetAmountRounded = truncateWithPrecision(targetAmount, 8);
     dispatch(
       orderInputSlice.actions.setTokenAmount({
-        amount: targetAmount,
+        amount: targetAmountRounded,
         bestBuy,
         bestSell,
         balanceToken1: balanceToken1,
@@ -568,14 +566,12 @@ function CurrencyInputGroupSettings(
     }
     const targetAmount = Math.min(
       isXRD ? balanceToken2 - XRD_FEE_ALLOWANCE : balanceToken2,
-      Calculator.divide(
-        Calculator.multiply(balanceToken2, percentage - 0.001),
-        100
-      )
+      Calculator.divide(Calculator.multiply(balanceToken2, percentage), 100)
     );
+    const targetAmountRounded = truncateWithPrecision(targetAmount, 8);
     dispatch(
       orderInputSlice.actions.setTokenAmount({
-        amount: targetAmount,
+        amount: targetAmountRounded,
         bestBuy,
         bestSell,
         balanceToken1: balanceToken1,

--- a/src/app/state/orderInputSlice.ts
+++ b/src/app/state/orderInputSlice.ts
@@ -11,7 +11,6 @@ import { RDT, getRdtOrThrow } from "../subscriptions";
 import { fetchAccountHistory } from "./accountHistorySlice";
 import { fetchBalances } from "./pairSelectorSlice";
 import {
-  displayNumber,
   getPrecision,
   truncateWithPrecision,
   updateIconIfNeeded,

--- a/src/app/state/orderInputSlice.ts
+++ b/src/app/state/orderInputSlice.ts
@@ -10,7 +10,12 @@ import { SdkResult } from "alphadex-sdk-js/lib/models/sdk-result";
 import { RDT, getRdtOrThrow } from "../subscriptions";
 import { fetchAccountHistory } from "./accountHistorySlice";
 import { fetchBalances } from "./pairSelectorSlice";
-import { displayNumber, updateIconIfNeeded } from "../utils";
+import {
+  displayNumber,
+  getPrecision,
+  truncateWithPrecision,
+  updateIconIfNeeded,
+} from "../utils";
 import { Calculator } from "../services/Calculator";
 
 export enum OrderType {
@@ -624,13 +629,19 @@ export const orderInputSlice = createSlice({
 function toDescription(quote: Quote): string {
   let quoteDescription = "";
   if (quote.fromAmount > 0 && quote.toAmount > 0) {
+    const fromAmount = truncateWithPrecision(
+      quote.fromAmount,
+      getPrecision(quote.fromToken.symbol)
+    );
+    const toAmount = truncateWithPrecision(
+      quote.toAmount,
+      getPrecision(quote.toToken.symbol)
+    );
+    const toTokenSymbol = quote.toToken.symbol;
+    const fromTokenSymbol = quote.fromToken.symbol;
     quoteDescription +=
-      `Sending ${displayNumber(quote.fromAmount, 8)} ${
-        quote.fromToken.symbol
-      } ` +
-      `to receive ${displayNumber(quote.toAmount, 8)} ${
-        quote.toToken.symbol
-      }.\n`;
+      `Sending ${fromAmount} ${fromTokenSymbol} ` +
+      `to receive ${toAmount} ${toTokenSymbol}.\n`;
   }
   if (quote.resultMessageLong) {
     quoteDescription += "\n" + quote.resultMessageLong;


### PR DESCRIPTION
This PR:
- fixes #383 
- replaces rounding with truncating on all balances shown in the frontend, to prevent situations like these:
![image](https://github.com/DeXter-on-Radix/website/assets/44790691/f0d87ad3-a0a9-4dd9-b4b3-c59ae9376dc6)
