### PR TITLE
Changes to subscriptions file

### DIFF
--- a/src/app/state/accountHistorySlice.ts
+++ b/src/app/state/accountHistorySlice.ts
@@ -7,7 +7,7 @@ import {
 import { RootState, AppDispatch } from "./store";
 import * as adex from "alphadex-sdk-js";
 import { SdkResult } from "alphadex-sdk-js/lib/models/sdk-result";
-import { getRdt, RDT } from "../subscriptions";
+import { rdt, RDT } from "../subscriptions";
 
 // TYPES AND INTERFACES
 export enum Tables {
@@ -58,7 +58,6 @@ export const cancelOrder = createAsyncThunk<
   { state: RootState }
 >("accountHistory/cancelOrder", async (payload, thunkAPI) => {
   const state = thunkAPI.getState();
-  const rdt = getRdt();
 
   if (!rdt) {
     throw new Error("RDT is not initialized yet.");

--- a/src/app/state/orderInputSlice.ts
+++ b/src/app/state/orderInputSlice.ts
@@ -7,7 +7,7 @@ import {
 import * as adex from "alphadex-sdk-js";
 import { RootState } from "./store";
 import { SdkResult } from "alphadex-sdk-js/lib/models/sdk-result";
-import { RDT, getRdtOrThrow } from "../subscriptions";
+import { RDT, rdt } from "../subscriptions";
 import { fetchAccountHistory } from "./accountHistorySlice";
 import { fetchBalances } from "./pairSelectorSlice";
 import { displayNumber, updateIconIfNeeded } from "../utils";
@@ -294,7 +294,6 @@ export const submitOrder = createAsyncThunk<
 >("orderInput/submitOrder", async (_arg, thunkAPI) => {
   const state = thunkAPI.getState();
   const dispatch = thunkAPI.dispatch;
-  const rdt = getRdtOrThrow();
   const result = await createTx(state, rdt);
   // Asynchronously update balances + account history
   await Promise.all([

--- a/src/app/state/pairSelectorSlice.ts
+++ b/src/app/state/pairSelectorSlice.ts
@@ -1,7 +1,7 @@
 import * as adex from "alphadex-sdk-js";
 import { PayloadAction, createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import { RootState } from "./store";
-import { getRdt } from "../subscriptions";
+import { rdt } from "../subscriptions";
 import { updateIconIfNeeded } from "../utils";
 
 export const AMOUNT_MAX_DECIMALS = adex.AMOUNT_MAX_DECIMALS;
@@ -49,7 +49,6 @@ export const fetchBalances = createAsyncThunk<
     return undefined;
   }
 
-  const rdt = getRdt();
   if (rdt && state.radix.walletData.accounts.length > 0) {
     const tokens = [state.pairSelector.token1, state.pairSelector.token2];
 

--- a/src/app/state/rewardSlice.ts
+++ b/src/app/state/rewardSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, createAsyncThunk, PayloadAction } from "@reduxjs/toolkit";
 import { RootState } from "./store";
-import { getRdtOrThrow } from "../subscriptions";
+import { rdt } from "../subscriptions";
 import { NonFungibleResourcesCollectionItem } from "@radixdlt/radix-dapp-toolkit";
 import {
   AccountRewards,
@@ -181,7 +181,6 @@ export const fetchReciepts = createAsyncThunk<
     state: RootState;
   }
 >("rewards/fetchReciepts", async (pairsList, thunkAPI) => {
-  const rdt = getRdtOrThrow();
   // const walletData = rdt.walletApi.getWalletData();
   const state = thunkAPI.getState();
   const accounts = state.radix.walletData.accounts;
@@ -289,7 +288,6 @@ export const fetchAddresses = createAsyncThunk<
     state: RootState;
   }
 >("rewards/fetchAddresses", async (_, thunkAPI) => {
-  const rdt = getRdtOrThrow();
   const state = thunkAPI.getState();
   if (!state.rewardSlice.config.rewardComponent) {
     throw new Error("Missing rewardComponent address");
@@ -324,7 +322,6 @@ export const claimRewards = createAsyncThunk<
     state: RootState;
   }
 >("rewards/claimRewards", async (_, thunkAPI) => {
-  const rdt = getRdtOrThrow();
   const state = thunkAPI.getState().rewardSlice;
 
   console.log("Claiming rewards. Rewards data: ", state.rewardData);

--- a/src/app/state/rewardUtils.tsx
+++ b/src/app/state/rewardUtils.tsx
@@ -1,5 +1,5 @@
 import { TokenInfo } from "alphadex-sdk-js";
-import { getRdtOrThrow } from "../subscriptions";
+import { rdt } from "../subscriptions";
 import { StateKeyValueStoreDataRequestKeyItem } from "@radixdlt/radix-dapp-toolkit";
 
 export class ClaimComponent {
@@ -192,7 +192,6 @@ export async function getAccountRewards(
   accountAddresses: string[],
   claimNFTResourceAddress: string
 ): Promise<AccountRewards[]> {
-  const rdt = getRdtOrThrow();
   let accountNftIds = accountAddresses.map((accountAddress) =>
     createAccountNftId(accountAddress)
   );
@@ -296,7 +295,6 @@ export async function getOrderRewards(
   receiptIds: string[]
 ): Promise<OrderRewards[]> {
   let result: OrderRewards[] = [];
-  const rdt = getRdtOrThrow();
   // console.log("Getting OrderRewards for receiptIds: ", receiptIds);
   const maxBatchSize = 90;
   let batchStart = 0;


### PR DESCRIPTION
This PR is to make a few suggested changes to the subscriptions file.

The biggest change is that it now exports a variable called rdt, which can just be imported and used anywhere else in the app. The rdt variable is initialised in the init subscriptions function which is called once when the app loads from a useEffect in the root layout component.
I also simplified the adex init call and added an interval to the init subscriptions function to show where to create intervals that need to always run in the app. This interval will be used in the new state management.

These changes were part of the new state management changes, but I wanted to do a separate PR so we can discuss and approve these changes separately.