### PR TITLE
[UI enhancment] add margin on mobile + make container rounded

### DIFF
--- a/src/app/rewards/page.tsx
+++ b/src/app/rewards/page.tsx
@@ -113,7 +113,7 @@ function RewardsCard() {
     }
   }, [dispatch, isConnected, account, pairsList]);
   return (
-    <div className="max-w-[400px] sm:max-w-[600px] w-full px-4 py-4 sm:px-12 sm:py-8 m-auto mt-2 sm:mt-14 mb-28 bg-[#191B1D]">
+    <div className="max-w-[400px] sm:max-w-[600px] px-4 py-4 sm:px-12 sm:py-8 m-auto mt-2 sm:mt-14 mb-28 bg-[#191B1D] rounded-xl max-[450px]:mx-5">
       <div className="flex flex-col">
         <div>
           <h4


### PR DESCRIPTION
In preparation of mobile launch I improved rewards page on mobile:
- added margin to make the card visible
- added rounded corner to make it more clear that its a card, not a section

![image](https://github.com/DeXter-on-Radix/website/assets/44790691/4d288006-48b6-4484-b1e9-18eec029a18d)
