### PR TITLE
Trigger deploy preview by setting label

### DIFF
--- a/.github/workflows/stokenet-deploy-main.yml
+++ b/.github/workflows/stokenet-deploy-main.yml
@@ -28,6 +28,7 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy-preview'))
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Since we currently can't merge PRs from forked repositories (due to lack of deploy preview on those), this PR tries to add the possibility to trigger deploy preview creation by setting a label "deploy-preview".

I also already created the label:
<img width="458" alt="Bildschirmfoto 2024-05-13 um 10 43 16" src="https://github.com/DeXter-on-Radix/website/assets/44790691/879151a9-6615-4c9c-ab24-2892278beba9">


Disclaimer: This was suggested by chatGPT, I am not sure this will actually work.