### PR TITLE
[BUGFIX] Fix lag in pair selector

### DIFF
--- a/src/app/state/pairSelectorSlice.ts
+++ b/src/app/state/pairSelectorSlice.ts
@@ -127,6 +127,7 @@ export const pairSelectorSlice = createSlice({
       const { pairAddress, pairName } = action.payload;
       adex.clientState.currentPairAddress = pairAddress;
       if (pairName) {
+        state.name = pairName; // Prevent empty pairname during loading
         setQueryParam("pair", formatPairName(pairName));
       }
     },


### PR DESCRIPTION
### Current Behavior
- The `pairSelector` waits for data to be fetched from Adex before updating the displayed pair.
- This results in a brief period where the `pairSelector` shows the old pair, causing a perceived lag or buggy experience for the user.

### Changes Introduced
- The `pairSelector` now instantly updates to show the selected pair.
- Since the `pairSelector` already has the necessary data, it no longer waits for the data fetch to complete before displaying the new pair.

This improvement enhances user experience by eliminating the lag between selecting and displaying the new pair.