### PR TITLE
Add link to order receipt nft

### DIFF
--- a/src/app/components/DisplayTable.tsx
+++ b/src/app/components/DisplayTable.tsx
@@ -21,6 +21,22 @@ import "../styles/table.css";
 import { DexterToast } from "./DexterToaster";
 import { PairInfo } from "alphadex-sdk-js/lib/models/pair-info";
 
+function createOrderReceiptAddressLookup(
+  pairsList: PairInfo[]
+): Record<string, string> {
+  const orderReceiptAddressLookup: Record<string, string> = {};
+  pairsList.forEach((pairInfo) => {
+    orderReceiptAddressLookup[pairInfo.address] = pairInfo.orderReceiptAddress;
+  });
+  return orderReceiptAddressLookup;
+}
+
+function getNftReceiptUrl(orderReceiptAddress: string, id: number) {
+  return `https://${
+    process.env.NEXT_PUBLIC_NETWORK === "stokenet" ? "stokenet-" : ""
+  }dashboard.radixdlt.com/nft/${orderReceiptAddress}%3A%23${id}%23`;
+}
+
 // The headers refer to keys specified in
 // src/app/state/locales/{languagecode}/trade.json
 const headers = {
@@ -197,20 +213,6 @@ const OpenOrdersRows = ({ data }: TableProps) => {
     </tr>
   );
 };
-
-function createOrderReceiptAddressLookup(
-  pairsList: PairInfo[]
-): Record<string, string> {
-  const orderReceiptAddressLookup: Record<string, string> = {};
-  pairsList.forEach((pairInfo) => {
-    orderReceiptAddressLookup[pairInfo.address] = pairInfo.orderReceiptAddress;
-  });
-  return orderReceiptAddressLookup;
-}
-
-function getNftReceiptUrl(orderReceiptAddress: string, id: number) {
-  return `https://dashboard.radixdlt.com/nft/${orderReceiptAddress}%3A%23${id}%23`;
-}
 
 const OrderHistoryRows = ({ data }: TableProps) => {
   const t = useTranslations();


### PR DESCRIPTION
resolves #363 by adding an extra column `ID` to the trade history tables.

preview:
![image](https://github.com/DeXter-on-Radix/website/assets/44790691/6287911b-595b-458e-aa68-08ce03f2324b)
