### PR TITLE
Reduce rewards page error toasts

### DIFF
--- a/src/app/rewards/page.tsx
+++ b/src/app/rewards/page.tsx
@@ -102,7 +102,10 @@ function RewardsCard() {
 
   useEffect(() => {
     async function loadRewards() {
-      await dispatch(fetchAddresses());
+      const fetchAddressesResult = await dispatch(fetchAddresses());
+      if (!fetchAddressesResult.payload) {
+        return; // quit if address could not be loaded
+      }
       let fetchReceiptsAction = await dispatch(fetchReciepts(pairsList));
       // console.log("fetchReceiptsAction: ", fetchReceiptsAction);
       await dispatch(fetchAccountRewards());

--- a/src/app/rewards/page.tsx
+++ b/src/app/rewards/page.tsx
@@ -101,16 +101,23 @@ function RewardsCard() {
   const userHasRewards = getUserHasRewards(rewardData);
 
   useEffect(() => {
+    // Performs 4 sequential actions:
+    // 1. fetchAddresses     : fetches relevant rewards component addresses
+    // 2. fetchAccountRewards: fetches rewards for a specific account
+    // 3. fetchReciepts      : fetches NFT reciepts
+    // 4. fetchOrderRewards  : fetches rewards based on the NFT reciepts
     async function loadRewards() {
       const fetchAddressesResult = await dispatch(fetchAddresses());
       if (!fetchAddressesResult.payload) {
-        return; // quit if address could not be loaded
+        return; // stop loading rewards if addresses could not be loaded
       }
-      let fetchReceiptsAction = await dispatch(fetchReciepts(pairsList));
-      // console.log("fetchReceiptsAction: ", fetchReceiptsAction);
       await dispatch(fetchAccountRewards());
+      let fetchReceiptsResult = await dispatch(fetchReciepts(pairsList));
+      if (!fetchReceiptsResult.payload) {
+        return; // stop loading order rewards if reciepts are not loaded successfully
+      }
       await dispatch(
-        fetchOrderRewards(fetchReceiptsAction.payload as string[])
+        fetchOrderRewards(fetchReceiptsResult.payload as string[])
       );
     }
     if (isConnected) {


### PR DESCRIPTION
Loading rewards consists of the following async actions:
-> fetchAddresses
-> fetchAccountRewards
-> fetchReciepts
-> fetchOrderRewards

Currently we don't stop execution if one of the actions fails, which leads to 3 error messages being thrown at the user at the same time (which is overwhelming). We can reduce those by adding some logic:
- if there is an error fetching addresses of the rewards component, there is no need to continue as all coninuing actions will fail
- if the NFT receipts are not properly loaded, theres no need to fetch AccountRewards, as those rely on the NFT receipts.

![Bildschirmfoto vom 2024-06-04 02-23-07](https://github.com/DeXter-on-Radix/website/assets/44790691/a6f14227-e01d-4503-a6db-bde084269149)
