### PR TITLE
remove deprecated WOWO/XRD pair

### DIFF
--- a/src/app/components/PairSelector.tsx
+++ b/src/app/components/PairSelector.tsx
@@ -5,10 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
 import React from "react";
 
-// List of coins that should be removed from the frontend.
-// Removing pairs requires a community vote / decision.
-// Those coins are still tradeable on alphadex.
-const BLACKLISTED_PAIRS: string[] = [];
+import { BLACKLISTED_PAIRS } from "../data/BLACKLISTED_PAIRS";
 
 interface PairInfo {
   name: string;

--- a/src/app/data/BLACKLISTED_PAIRS.ts
+++ b/src/app/data/BLACKLISTED_PAIRS.ts
@@ -1,0 +1,11 @@
+/*
+ * This file contains all alphadex trade pairs that are
+ * blacklisted on DEXTER. Blacklisting of trade pairs requires
+ * either a vote by the DEXTER community or technical reasons
+ * (e.g. token migration)
+ */
+
+export const BLACKLISTED_PAIRS: string[] = [
+  // WOWO/XRD: Due to token migration the old WOWO token is now deprecated
+  "component_rdx1cr4urwgxap6xvyjlnudg08sk9t2gsdqrxh9mvetxs8kqlcyxh07qd3",
+];


### PR DESCRIPTION
As [discussed via Telegram](https://t.me/dexter_discussion/16662), removing deprecated WOWO/XRD pair from the frontend (as the token was migrated from WonderWoman to WOWO.