### PR TITLE
Add `npm run test-all` script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Here are a few guidelines to follow:
 - **Make PRs small and focused on a single change** so they are easier to review and merge
 - **Make PRs complete** so that the new feature is functional
 - **Write tests** to prevent regressions, unit tests with [Jest](https://jestjs.io/) in `__tests__` folder, end to end tests with [Playwright](https://playwright.dev/) in `e2e` folder
+- **Run tests locally** with `npm run test-all` before submitting any PR. This will help you find issues fast.
 - **Try to avoid custom CSS** - the project uses [DaisyUI](https://daisyui.com/) and [TailwindCSS](https://tailwindcss.com/docs/) for styling, whenever possible use the existing components and classes, the full rationale (by creator of TailwindCSS) is [here](https://adamwathan.me/css-utility-classes-and-separation-of-concerns/)
 
 If you happen to use VS Code, install the recommended extensions to get automatic formatting and linting on save, they are listed in `.vscode/extensions.json` and VS Code will prompt you to install them.

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "lint": "next lint",
     "test": "vitest",
     "test-integration": "playwright test",
-    "copy-pr": "node ./scripts/copy-pr.js",
-    "test-all": "npm run lint && npm run test && npm run test-integration"
+    "test-all": "npm run lint && npm run test && npm run test-integration",
+    "copy-pr": "node ./scripts/copy-pr.js"
   },
   "dependencies": {
     "@mdx-js/loader": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "next lint",
     "test": "vitest",
     "test-integration": "playwright test",
-    "copy-pr": "node ./scripts/copy-pr.js"
+    "copy-pr": "node ./scripts/copy-pr.js",
+    "test-all": "npm run lint && npm run test && npm run test-integration"
   },
   "dependencies": {
     "@mdx-js/loader": "^3.0.0",


### PR DESCRIPTION
Usually before submitting a PR, I run the following commands locally:
- `npm run lint` to ensure formatting is correct
- `npm run test` to run vitest unit tests
- `npm run test-integration` to run playwright integration tests

To simplify the flow I added a script that runs all commands in succession for better dev experience:
`npm run test-all`

