### PR TITLE
[Fix]: rewards chest misplaced in mobile screens

### DIFF
--- a/src/app/rewards/page.tsx
+++ b/src/app/rewards/page.tsx
@@ -77,7 +77,7 @@ function HeaderComponent() {
             <DexterParagraph text={t("earn_rewards_by")} />
           </div>
         </div>
-        <div className="sm:w-[38%] max-[640px]:max-w-[200px] sm:ml-5">
+        <div className="sm:w-[38%] max-[640px]:max-w-[200px] sm:ml-5 mx-auto">
           <img
             src="/rewards/chest.png"
             alt="treasury"


### PR DESCRIPTION
Minor pr that resolves https://github.com/DeXter-on-Radix/website/issues/452