### PR TITLE
refactor resetBalances() reducer

### DIFF
--- a/src/app/state/pairSelectorSlice.ts
+++ b/src/app/state/pairSelectorSlice.ts
@@ -144,8 +144,8 @@ export const pairSelectorSlice = createSlice({
       }
     },
     resetBalances: (state: PairSelectorState) => {
-      state.token1.balance = undefined;
-      state.token2.balance = undefined;
+      delete state.token1.balance;
+      delete state.token2.balance;
     },
   },
 

--- a/src/app/state/pairSelectorSlice.ts
+++ b/src/app/state/pairSelectorSlice.ts
@@ -144,18 +144,8 @@ export const pairSelectorSlice = createSlice({
       }
     },
     resetBalances: (state: PairSelectorState) => {
-      const [token1State, token2State] = [
-        { ...state.token1 },
-        { ...state.token2 },
-      ];
-      delete token1State.balance;
-      delete token2State.balance;
-
-      return {
-        ...state,
-        ["token1"]: token1State,
-        ["token2"]: token2State,
-      };
+      state.token1.balance = undefined;
+      state.token2.balance = undefined;
     },
   },
 


### PR DESCRIPTION
When using redux-toolkit and `createSlice()` function, modifying state is allowed, hence we can simplify the function. 
See full discussion here: #458 

