### PR TITLE
remove seconds from timestamp

### DIFF
--- a/src/app/components/AccountHistory.tsx
+++ b/src/app/components/AccountHistory.tsx
@@ -252,7 +252,7 @@ const OpenOrdersRows = ({ data }: TableProps) => {
         <td className={displayOrderSide(order.side).className}>
           {t(displayOrderSide(order.side).text)}
         </td>
-        <td>{displayTime(order.timeSubmitted, "full")}</td>
+        <td>{displayTime(order.timeSubmitted, "full_without_seconds")}</td>
         <td>
           {order.amount} {order.specifiedToken.symbol}
         </td>
@@ -336,8 +336,8 @@ const OrderHistoryRows = ({ data }: TableProps) => {
         <td>
           {calculateTotalFees(order)} {order.unclaimedToken.symbol}
         </td>
-        <td>{displayTime(order.timeSubmitted, "full")}</td>
-        <td>{displayTime(order.timeCompleted, "full")}</td>
+        <td>{displayTime(order.timeSubmitted, "full_without_seconds")}</td>
+        <td>{displayTime(order.timeCompleted, "full_without_seconds")}</td>
       </tr>
     ))
   ) : (

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -217,6 +217,19 @@ export function displayTime(
         hour12: false,
       })
       .replace(/(\d+)\/(\d+)\/(\d+), (\d+:\d+:\d+)/, "$3-$1-$2 $4");
+    // TODO: remove once adex supports higher precision (seconds)
+  } else if (period === "full_without_seconds") {
+    return date
+      .toLocaleString("en-US", {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        // second: "2-digit", // <- seconds removed
+        hour12: false,
+      })
+      .replace(/(\d+)\/(\d+)\/(\d+), (\d+:\d+:\d+)/, "$3-$1-$2 $4");
   } else if (!period) {
     return date.toLocaleString([], {
       month: "2-digit",


### PR DESCRIPTION
Currently the `orderSubmitted` and `orderCompleted` timestamps from the [adex API](https://socket.dev/npm/package/alphadex-sdk-js) only return values that have minute precision. This will change in the future, but for now disabling the seconds to remove the unneccessary used space. 

## Before
![Bildschirmfoto vom 2024-06-24 13-34-04](https://github.com/DeXter-on-Radix/website/assets/44790691/df10554b-7df5-41a2-8a21-dfc4f158d40a)


## After
![Bildschirmfoto vom 2024-06-24 13-33-24](https://github.com/DeXter-on-Radix/website/assets/44790691/a1a1d252-12a7-4f8b-bef2-99d436d97529)


We can add it back in once radix/adex fixes this issue. Here is some more context (message from [Telegram](https://t.me/alphadex_xrd/1098):

![Bildschirmfoto vom 2024-06-24 13-35-52](https://github.com/DeXter-on-Radix/website/assets/44790691/7ea97e7a-4814-4a4f-9b7f-890082cfb463)
