### PR TITLE
Add avg price and slippage to tooltip on market orders

### DIFF
--- a/src/app/state/orderInputSlice.ts
+++ b/src/app/state/orderInputSlice.ts
@@ -628,6 +628,8 @@ export const orderInputSlice = createSlice({
 
 function toDescription(quote: Quote): string {
   let quoteDescription = "";
+  const token2symbol = "XRD"; // TODO: import as parameter
+  const lastPrice = 0.5; // TODO: import
   if (quote.fromAmount > 0 && quote.toAmount > 0) {
     const fromAmount = truncateWithPrecision(
       quote.fromAmount,
@@ -639,9 +641,18 @@ function toDescription(quote: Quote): string {
     );
     const toTokenSymbol = quote.toToken.symbol;
     const fromTokenSymbol = quote.fromToken.symbol;
+    const avgPrice = Calculator.multiply(
+      Calculator.divide(1, toAmount),
+      fromAmount
+    );
+    const slippageInPerc = Math.round(
+      Calculator.divide(avgPrice, lastPrice) * 100
+    );
     quoteDescription +=
       `Sending ${fromAmount} ${fromTokenSymbol} ` +
-      `to receive ${toAmount} ${toTokenSymbol}.\n`;
+      `to receive ${toAmount} ${toTokenSymbol}.\n\n` +
+      `Average price: ${avgPrice.toFixed(4)} ${token2symbol}` +
+      `slippage: ${slippageInPerc}%\n`;
   }
   if (quote.resultMessageLong) {
     quoteDescription += "\n" + quote.resultMessageLong;

--- a/src/app/state/orderInputSlice.ts
+++ b/src/app/state/orderInputSlice.ts
@@ -628,8 +628,6 @@ export const orderInputSlice = createSlice({
 
 function toDescription(quote: Quote): string {
   let quoteDescription = "";
-  const token2symbol = "XRD"; // TODO: import as parameter
-  const lastPrice = 0.5; // TODO: import
   if (quote.fromAmount > 0 && quote.toAmount > 0) {
     const fromAmount = truncateWithPrecision(
       quote.fromAmount,
@@ -641,18 +639,11 @@ function toDescription(quote: Quote): string {
     );
     const toTokenSymbol = quote.toToken.symbol;
     const fromTokenSymbol = quote.fromToken.symbol;
-    const avgPrice = Calculator.multiply(
-      Calculator.divide(1, toAmount),
-      fromAmount
-    );
-    const slippageInPerc = Math.round(
-      Calculator.divide(avgPrice, lastPrice) * 100
-    );
     quoteDescription +=
       `Sending ${fromAmount} ${fromTokenSymbol} ` +
       `to receive ${toAmount} ${toTokenSymbol}.\n\n` +
-      `Average price: ${avgPrice.toFixed(4)} ${token2symbol}` +
-      `slippage: ${slippageInPerc}%\n`;
+      `Average price: ${quote.avgPrice}.\n` +
+      `slippage: ${Math.round(quote.slippage * 100)}%.\n`;
   }
   if (quote.resultMessageLong) {
     quoteDescription += "\n" + quote.resultMessageLong;


### PR DESCRIPTION
resolves #374. 

In the order summary tooltip for market orders, the user currently only sees the amount sent and amount received. This PR adds additional important information like average price and slippage to the tooltip. 

![image](https://github.com/DeXter-on-Radix/website/assets/44790691/1b56edc2-48dc-413f-8826-28ed51baa8b8)
