### PR TITLE
remove banner for ended liquidity boost

### DIFF
--- a/src/app/trade/page.tsx
+++ b/src/app/trade/page.tsx
@@ -55,13 +55,6 @@ export default function Trade() {
     <div className="grow">
       <PromoBannerCarousel
         items={[
-          // HNY liquidity incentive program
-          {
-            imageUrl: "/promo-banners/honey-desktop.svg",
-            imageUrlMobile: "/promo-banners/honey-mobile.svg",
-            redirectUrl: "https://dexteronradix.com/trade?pair=hny-xrd",
-            redirectOpensInSameTab: true,
-          },
           // tokentrek banner
           {
             imageUrl: "/promo-banners/tokentrek-desktop.svg",


### PR DESCRIPTION
Liquidity program ended for HNY, so removing banner.