### PR TITLE
fix cancelling rewards not possible

### DIFF
--- a/src/app/components/AccountHistory.tsx
+++ b/src/app/components/AccountHistory.tsx
@@ -88,7 +88,7 @@ function OrdersTabs() {
 export function AccountHistory() {
   const dispatch = useAppDispatch();
   const account = useAppSelector(
-    (state) => state.radix?.walletData.accounts[0]?.address
+    (state) => state.radix?.selectedAccount?.address
   );
   const pairAddress = useAppSelector((state) => state.pairSelector.address);
 

--- a/src/app/state/accountHistorySlice.ts
+++ b/src/app/state/accountHistorySlice.ts
@@ -72,7 +72,7 @@ export const batchCancel = createAsyncThunk<
 >("accountHistory/batchCancel", async (payload, thunkAPI) => {
   const state = thunkAPI.getState();
   const orders: Order[] = payload;
-  const account = state.radix?.walletData.accounts[0]?.address || "";
+  const account = state.radix?.selectedAccount?.address || "";
   if (!account) {
     return thunkAPI.rejectWithValue("Account missing");
   }
@@ -126,7 +126,7 @@ async function createCancelTx(
   pairAddress: string,
   rdt: RDT
 ) {
-  const account = state.radix?.walletData.accounts[0]?.address || "";
+  const account = state.radix?.selectedAccount?.address || "";
 
   const createCancelOrderResponse = await adex.createCancelOrderTx(
     pairAddress,


### PR DESCRIPTION
Currently you can only cancel orders from the first account selected. When selecting another account from the wallet dropdown list both cancel and batchCancel transactions fail.

This PR fixes this issue.

