### PR TITLE
add totalUsers to landing page stats widget

### DIFF
--- a/src/app/components/StatsWidget.tsx
+++ b/src/app/components/StatsWidget.tsx
@@ -27,15 +27,10 @@ const StatsWidget = () => {
     })();
   }, []);
 
-  // TODO: compute actual users with a script fetching all orders on adex.
   // 1. google sheet data
-  // 1.1. socials data
-  const socials = kpiData?.socials;
-  const numOfIgFollowers = socials?.instagramFollowers ?? 0;
-  const numOfXFollowers = socials?.twitterFollowers ?? 0;
-  const numOfUTubeFollowers = socials?.youtubeSubscribers ?? 0;
-  const totalNumOfFollowers =
-    numOfIgFollowers + numOfXFollowers + numOfUTubeFollowers;
+  // 1.1. total users + total orders
+  const totalUsers = kpiData?.totalUsers;
+  // const totalOrders = kpiData?.totalOrders;
 
   // 1.2. trade volume data - total & weekly - XRD & USD
   const tradeVolume = kpiData?.tradeVolume;
@@ -53,10 +48,10 @@ const StatsWidget = () => {
   return (
     <div className="flex w-full opacity-80 flex-col gap-y-8 mx-auto justify-center items-center mt-8 mb-32">
       {/* users */}
-      {totalNumOfFollowers ? (
+      {totalUsers ? (
         <>
           <AnimatedCounter
-            end={totalNumOfFollowers}
+            end={totalUsers}
             decimals={0}
             label={<span className="uppercase">{t("users_trust_us")}</span>}
             wrapperClassName="w-full flex justify-center max-md:flex-col max-md:text-3xl md:text-4xl items-center gap-2 max-md:gap-4"

--- a/src/app/kpis/kpis-utils.ts
+++ b/src/app/kpis/kpis-utils.ts
@@ -18,6 +18,8 @@ export interface KpiData {
     uniqueVisitors: WeeklySnapshot[];
     pageRequests: WeeklySnapshot[];
   };
+  totalUsers: number;
+  totalOrders: number;
 }
 
 interface WeeklySnapshot {
@@ -113,6 +115,10 @@ function extractData(rawData: string): KpiData {
   const instagramFollowers = extractNumbersFromRow(rows[7]).slice(-1)[0];
   const twitterFollowers = extractNumbersFromRow(rows[6]).slice(-1)[0];
 
+  // Get User + Order Count
+  const totalUsers = extractNumbersFromRow(rows[2]).slice(-1)[0];
+  const totalOrders = extractNumbersFromRow(rows[3]).slice(-1)[0];
+
   return {
     tradeVolume: {
       total: {
@@ -133,5 +139,7 @@ function extractData(rawData: string): KpiData {
       twitterFollowers,
       instagramFollowers,
     },
+    totalUsers: totalUsers,
+    totalOrders: totalOrders,
   } as KpiData;
 }


### PR DESCRIPTION
Currently the landing page shows the following "users that trust us" number inside the stats widget:

![image](https://github.com/user-attachments/assets/c711d170-25ed-472b-a927-cb2c66b8ae03)

But this number is inaccurate, as it just counts all followers from instagram, youtube and telegram. 

This PR updates the numbers to actually reflect unique radix wallet addresses that used DeXter at least once since inception by using the script generated by @SiegfriedBz. 

So as an update, we have:
- 689 Users (unique wallet addresses)
- 7110 Total Orders places

Disclaimer: these numbers do not exclude trades outside of DeXter but simply count all orders on alphadex (without filtering for platformId).