### PR TITLE
fix AnimatedCounter label css

### DIFF
--- a/src/app/components/StatsWidget.tsx
+++ b/src/app/components/StatsWidget.tsx
@@ -61,7 +61,7 @@ const StatsWidget = () => {
             label={<span className="uppercase">{t("users_trust_us")}</span>}
             wrapperClassName="w-full flex justify-center max-md:flex-col max-md:text-3xl md:text-4xl items-center gap-2 max-md:gap-4"
             counterClassName="text-dexter-green-OG font-bold min-w-44 max-md:text-center md:text-right"
-            labelClassName="ml-2"
+            labelClassName="md:ml-2 text-center"
           />
         </>
       ) : null}

--- a/src/app/components/StatsWidget.tsx
+++ b/src/app/components/StatsWidget.tsx
@@ -61,7 +61,7 @@ const StatsWidget = () => {
             label={<span className="uppercase">{t("users_trust_us")}</span>}
             wrapperClassName="w-full flex justify-center max-md:flex-col max-md:text-3xl md:text-4xl items-center gap-2 max-md:gap-4"
             counterClassName="text-dexter-green-OG font-bold min-w-44 max-md:text-center md:text-right"
-            labelClassName="md:ml-2 text-center"
+            labelClassName="px-4 text-center"
           />
         </>
       ) : null}


### PR DESCRIPTION
center AnimatedCounter label in StatsWidget to fix the following issue:

<img width="359" alt="Bildschirmfoto 2024-08-02 um 01 15 32" src="https://github.com/user-attachments/assets/cb824183-f4bf-4c82-9e1e-f45f08d19322">
