### PR TITLE
make stats widget a standalone section

### DIFF
--- a/src/app/components/StatsWidget.tsx
+++ b/src/app/components/StatsWidget.tsx
@@ -46,7 +46,7 @@ const StatsWidget = () => {
   const numOfPairs = pairsList.length;
 
   return (
-    <div className="flex w-full opacity-80 flex-col gap-y-8 mx-auto justify-center items-center mt-8 mb-32">
+    <div className="flex w-full opacity-80 flex-col gap-y-8 mx-auto justify-center items-center py-32 bg-dexter-grey-dark">
       {/* users */}
       {totalUsers ? (
         <>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -345,7 +345,7 @@ function getTokenomicsTopicSectionProps(
     </>
   );
   return {
-    backgroundColor: "bg-dexter-grey-dark",
+    backgroundColor: "bg-dexter-grey-light",
     title: t("dextr_token"),
     body: tokenomicsBody,
     imageUrl: "/landing/sections/dexter-mascotte-holding-coin.png",
@@ -360,7 +360,7 @@ function getTradeTopicSectionProps(
   t: (key: string) => string // translation dict needs to be passed in
 ): TopicSectionProps {
   return {
-    backgroundColor: "bg-dexter-grey-light",
+    backgroundColor: "bg-dexter-grey-dark",
     title: t("earn_rewards_by_trading"),
     body: <DexterParagraph text={t("earn_rewards_by_trading_and")} />,
     imageUrl: "/landing/sections/treasury-earn-by-trading.png",
@@ -375,7 +375,7 @@ function getStakeTopicSectionProps(
   t: (key: string) => string // translation dict needs to be passed in
 ): TopicSectionProps {
   return {
-    backgroundColor: "bg-dexter-grey-dark",
+    backgroundColor: "bg-dexter-grey-light",
     title: t("stake_xrd_to_earn_dextr"),
     body: <DexterParagraph text={t("delegate_your_xrd_to_our")} />,
     imageUrl: "/landing/sections/staking-safe.png",
@@ -390,7 +390,7 @@ function getContributeTopicSectionProps(
   t: (key: string) => string // translation dict needs to be passed in
 ): TopicSectionProps {
   return {
-    backgroundColor: "bg-dexter-grey-light",
+    backgroundColor: "bg-dexter-grey-dark",
     title: t("earn_dextr_by_contributing"),
     body: <DexterParagraph text={t("whether_you_are_a_developer")} />,
     imageUrl: "/landing/sections/hands.png",


### PR DESCRIPTION
This PR makes the stats widget a standalone section, to make the scroll experience more natural. Previously the stats box appeared to belong to the hero section, and thus the big gap felt weird. 

Now as standalone section it feels more natural and is visually separated.

Discussion reference on discord:
https://discord.com/channels/1125689933735145503/1266737549548851252/1268980904068644936