### PR TITLE
fix account history fetching bug

### DIFF
--- a/src/app/state/accountHistorySlice.ts
+++ b/src/app/state/accountHistorySlice.ts
@@ -79,7 +79,7 @@ export const fetchAccountHistoryAllPairs = createAsyncThunk<
     (pairInfo) => pairInfo.address
   );
 
-  const account = state.radix?.walletData.accounts[0]?.address || "";
+  const account = state.radix?.selectedAccount?.address || "";
 
   const orderHistoryPromises = pairAddresses.map((pairAddress) =>
     adex.getAccountOrders(account, pairAddress, 0)


### PR DESCRIPTION
We have a bug where account history orders (for all other pairs) are only fetched for the first account. When switching accounts from the dropdown, it continues to fetch orders from the first account instead of the selected one.

Please merge ASAP. 😊