### PR TITLE
add link to roadmap in footer

### DIFF
--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -26,6 +26,10 @@ export function Footer() {
         text: t("KPIs"),
         url: "/kpis",
       },
+      {
+        text: t("roadmap"),
+        url: "https://ductus.notion.site/DeXter-Roadmap-e8faed71fe1c4cdf95fb247f682c0d3a",
+      },
     ],
   };
   const contentColumn2 = {

--- a/src/app/state/locales/en/footer.json
+++ b/src/app/state/locales/en/footer.json
@@ -17,5 +17,6 @@
   "talk_to_us": "Talk to us",
   "report_bug": "Report bug",
   "support": "Support",
-  "report_translation_issue": "Report translation issue"
+  "report_translation_issue": "Report translation issue",
+  "roadmap": "Roadmap"
 }

--- a/src/app/state/locales/pt/footer.json
+++ b/src/app/state/locales/pt/footer.json
@@ -17,5 +17,6 @@
   "talk_to_us": "Fale conosco",
   "report_bug": "Relatar erro",
   "support": "Suporte",
-  "report_translation_issue": "Relatar problema de tradução"
+  "report_translation_issue": "Relatar problema de tradução",
+  "roadmap": "Mapa rodoviário"
 }


### PR DESCRIPTION
This PR adds a link in the footer linking to an MVP version of a roadmap (or more accurate feature list). 

The roadmap was created in Notion by me. I am happy to add/change things. Current version:
https://ductus.notion.site/DeXter-Roadmap-e8faed71fe1c4cdf95fb247f682c0d3a

Related to #562.