### PR TITLE
Add roadmap to navbar

### DIFF
--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -43,6 +43,10 @@ const NavItems: { path: string; title: string }[] = [
     path: "/rewards",
     title: "rewards",
   },
+  {
+    path: "/roadmap",
+    title: "roadmap",
+  },
 ];
 
 export function Navbar() {


### PR DESCRIPTION
Adding the roadmap link as a navbar item to give more exposure to it. I believe it's better to have it up there prominently rather than hiding in the footer.