### PR TITLE
Add treasury shortlink

### DIFF
--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -30,6 +30,10 @@ export function Footer() {
         text: t("roadmap"),
         url: "https://ductus.notion.site/DeXter-Roadmap-e8faed71fe1c4cdf95fb247f682c0d3a",
       },
+      {
+        text: t("treasury"),
+        url: "https://dashboard.radixdlt.com/account/account_rdx168qrzyngejus9nazhp7rw9z3qn2r7uk3ny89m5lwvl299ayv87vpn5",
+      },
     ],
   };
   const contentColumn2 = {

--- a/src/app/state/locales/en/footer.json
+++ b/src/app/state/locales/en/footer.json
@@ -18,5 +18,6 @@
   "report_bug": "Report bug",
   "support": "Support",
   "report_translation_issue": "Report translation issue",
-  "roadmap": "Roadmap"
+  "roadmap": "Roadmap",
+  "treasury": "Treasury"
 }

--- a/src/app/state/locales/pt/footer.json
+++ b/src/app/state/locales/pt/footer.json
@@ -18,5 +18,6 @@
   "report_bug": "Relatar erro",
   "support": "Suporte",
   "report_translation_issue": "Relatar problema de tradução",
-  "roadmap": "Roadmap"
+  "roadmap": "Roadmap",
+  "treasury": "Treasury"
 }

--- a/src/app/treasury/page.tsx
+++ b/src/app/treasury/page.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+const Treasury = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.push(
+      "https://dashboard.radixdlt.com/account/account_rdx168qrzyngejus9nazhp7rw9z3qn2r7uk3ny89m5lwvl299ayv87vpn5"
+    );
+  }, [router]);
+
+  return null;
+};
+
+export default Treasury;


### PR DESCRIPTION
This PR adds the possibility to directly get to the treasury account by going to 
dexteronradix.com/treasury

The idea being that it can be user as a shortlink to share anywhere and looks more legit than simply the radix dashboard link.

I also added the link to the footer, but did not add it to the navbar, as its a secondary action (I would even argue its a hidden action as we only really need the shortlink).