### PR TITLE
buy sell panel slider improvements

### DIFF
--- a/src/app/components/OrderInput.tsx
+++ b/src/app/components/OrderInput.tsx
@@ -370,6 +370,7 @@ function SubmitButton() {
     side,
     type,
     token1,
+    token2,
     quote,
     quoteDescription,
     quoteError,
@@ -382,7 +383,9 @@ function SubmitButton() {
   const hasQuoteError = quoteError !== undefined;
   const isLimitOrder = type === OrderType.LIMIT;
   const isBuyOrder = side === OrderSide.BUY;
+  const isZeroAmount = token1.amount === 0 || token2.amount === 0;
   const disabled =
+    isZeroAmount ||
     !hasQuote ||
     hasQuoteError ||
     !isConnected ||

--- a/src/app/components/OrderInput.tsx
+++ b/src/app/components/OrderInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, ChangeEvent } from "react";
+import { useEffect, useState, useRef, ChangeEvent, useCallback } from "react";
 import { AiOutlineInfoCircle } from "react-icons/ai";
 import Tippy from "@tippyjs/react";
 import "tippy.js/dist/tippy.css";
@@ -472,45 +472,52 @@ function UserInputContainer() {
   const isBuyOrder = side === "BUY";
   const isSellOrder = side === "SELL";
 
+  const sliderCallback = useCallback(
+    (newPercentage: number) => {
+      const isXRDToken = isBuyOrder
+        ? token2.symbol === "XRD"
+        : token1.symbol === "XRD";
+      let balance = isBuyOrder ? balanceToken2 : balanceToken1;
+
+      if (newPercentage === 100 && isXRDToken) {
+        balance = Math.max(balance - XRD_FEE_ALLOWANCE, 0);
+      }
+
+      const amount = Calculator.divide(
+        Calculator.multiply(balance, newPercentage),
+        100
+      );
+
+      const specifiedToken = isBuyOrder
+        ? SpecifiedToken.TOKEN_2
+        : SpecifiedToken.TOKEN_1;
+
+      dispatch(
+        orderInputSlice.actions.setTokenAmount({
+          amount,
+          bestBuy,
+          bestSell,
+          balanceToken1,
+          balanceToken2,
+          specifiedToken,
+        })
+      );
+    },
+    [
+      isBuyOrder,
+      token1.symbol,
+      token2.symbol,
+      balanceToken1,
+      balanceToken2,
+      bestBuy,
+      bestSell,
+      dispatch,
+    ]
+  );
+
   useEffect(() => {
-    if (isMarketOrder) {
-      sliderCallback(0, "MARKET");
-    } else if (isLimitOrder) {
-      sliderCallback(0, "LIMIT");
-    }
-  }, [isBuyOrder, isSellOrder, isMarketOrder, isLimitOrder]);
-
-  const sliderCallback = (newPercentage: number, type: string) => {
-    console.log(`Type is: ${type}`);
-    const isXRDToken = isBuyOrder
-      ? token2.symbol === "XRD"
-      : token1.symbol === "XRD";
-    let balance = isBuyOrder ? balanceToken2 : balanceToken1;
-
-    if (newPercentage === 100 && isXRDToken) {
-      balance = Math.max(balance - XRD_FEE_ALLOWANCE, 0);
-    }
-
-    const amount = Calculator.divide(
-      Calculator.multiply(balance, newPercentage),
-      100
-    );
-
-    const specifiedToken = isBuyOrder
-      ? SpecifiedToken.TOKEN_2
-      : SpecifiedToken.TOKEN_1;
-
-    dispatch(
-      orderInputSlice.actions.setTokenAmount({
-        amount,
-        bestBuy,
-        bestSell,
-        balanceToken1,
-        balanceToken2,
-        specifiedToken,
-      })
-    );
-  };
+    sliderCallback(0);
+  }, [isBuyOrder, isSellOrder, isMarketOrder, isLimitOrder, sliderCallback]);
 
   return (
     <div className="bg-base-100 px-5 pb-5 rounded-b">
@@ -523,7 +530,7 @@ function UserInputContainer() {
           <PercentageSlider
             initialPercentage={0}
             callbackOnPercentageUpdate={(newPercentage) =>
-              sliderCallback(newPercentage, type)
+              sliderCallback(newPercentage)
             }
             isLimitOrder={isLimitOrder}
             isBuyOrder={isBuyOrder}
@@ -544,7 +551,7 @@ function UserInputContainer() {
           <PercentageSlider
             initialPercentage={0}
             callbackOnPercentageUpdate={(newPercentage) =>
-              sliderCallback(newPercentage, type)
+              sliderCallback(newPercentage)
             }
             isLimitOrder={isLimitOrder}
             isBuyOrder={isBuyOrder}

--- a/src/app/components/OrderInput.tsx
+++ b/src/app/components/OrderInput.tsx
@@ -530,6 +530,12 @@ function UserInputContainer() {
             userAction={UserAction.UPDATE_PRICE}
             disabled={true}
           />
+          {isSellOrder && ( // specify "Quantity"
+            <CurrencyInputGroup userAction={UserAction.SET_TOKEN_1} />
+          )}
+          {isBuyOrder && ( // specify "Total"
+            <CurrencyInputGroup userAction={UserAction.SET_TOKEN_2} />
+          )}
           <PercentageSlider
             initialPercentage={0}
             callbackOnPercentageUpdate={(newPercentage) =>
@@ -539,12 +545,6 @@ function UserInputContainer() {
             isBuyOrder={isBuyOrder}
             isSellOrder={isSellOrder}
           />
-          {isSellOrder && ( // specify "Quantity"
-            <CurrencyInputGroup userAction={UserAction.SET_TOKEN_1} />
-          )}
-          {isBuyOrder && ( // specify "Total"
-            <CurrencyInputGroup userAction={UserAction.SET_TOKEN_2} />
-          )}
         </>
       )}
       {isLimitOrder && (

--- a/src/app/components/OrderInput.tsx
+++ b/src/app/components/OrderInput.tsx
@@ -962,7 +962,7 @@ const PercentageSlider: React.FC<PercentageSliderProps> = ({
 
   return (
     <>
-      <div className="slider-container rounded-md w-full relative mt-5">
+      <div className="slider-container rounded-md w-full relative mt-5 opacity-70">
         <div className="absolute w-full">
           <input
             type="range"

--- a/src/app/components/OrderInput.tsx
+++ b/src/app/components/OrderInput.tsx
@@ -960,6 +960,11 @@ const PercentageSlider: React.FC<PercentageSliderProps> = ({
     isSellOrder,
   ]);
 
+  const handleClickOnLabel = (newPercentage: number) => {
+    setPercentage(newPercentage);
+    callbackOnPercentageUpdate(newPercentage);
+  };
+
   return (
     <>
       <div className="slider-container rounded-md w-full relative mt-5 opacity-70">
@@ -1029,30 +1034,38 @@ const PercentageSlider: React.FC<PercentageSliderProps> = ({
         <div className="w-full">
           <div className="slider-labels">
             <div className="flex justify-between text-xxs mt-1 mb-5">
-              <span className="absolute" style={{ left: "0%" }}>
+              <span
+                className="absolute select-none"
+                style={{ left: "0%" }}
+                onClick={() => handleClickOnLabel(0)}
+              >
                 0%
               </span>
               <span
-                className="absolute"
+                className="absolute select-none cursor-pointer"
                 style={{ left: "25%", transform: "translateX(-50%)" }}
+                onClick={() => handleClickOnLabel(25)}
               >
                 25%
               </span>
               <span
-                className="absolute"
+                className="absolute select-none cursor-pointer"
                 style={{ left: "50%", transform: "translateX(-50%)" }}
+                onClick={() => handleClickOnLabel(50)}
               >
                 50%
               </span>
               <span
-                className="absolute"
+                className="absolute select-none cursor-pointer"
                 style={{ left: "75%", transform: "translateX(-50%)" }}
+                onClick={() => handleClickOnLabel(75)}
               >
                 75%
               </span>
               <span
-                className="absolute"
+                className="absolute select-none cursor-pointer"
                 style={{ left: "100%", transform: "translateX(-100%)" }}
+                onClick={() => handleClickOnLabel(100)}
               >
                 100%
               </span>

--- a/src/app/state/locales/en/errors.json
+++ b/src/app/state/locales/en/errors.json
@@ -1,7 +1,6 @@
 {
   "UNSPECIFIED_PRICE": "Price must be specified",
   "NONZERO_PRICE": "Price must be greater than 0",
-  "NONZERO_AMOUNT": "Amount must be greater than 0",
   "HIGH_PRICE": "Price is significantly higher than best sell",
   "LOW_PRICE": "Price is significantly lower than best buy",
   "EXCESSIVE_DECIMALS": "Too many decimal places",

--- a/src/app/state/locales/pt/errors.json
+++ b/src/app/state/locales/pt/errors.json
@@ -1,7 +1,6 @@
 {
   "UNSPECIFIED_PRICE": "Preço deve ser especificado",
   "NONZERO_PRICE": "Preço deve ser maior que 0",
-  "NONZERO_AMOUNT": "Quantidade deve ser maior que 0",
   "HIGH_PRICE": "Preço está significativamente maior que a melhor oferta de venda",
   "LOW_PRICE": "Preço está significativamente menor que a melhor oferta de compra",
   "EXCESSIVE_DECIMALS": "Excesso de casas decimais",

--- a/src/app/state/orderInputSlice.ts
+++ b/src/app/state/orderInputSlice.ts
@@ -40,7 +40,6 @@ export enum SpecifiedToken {
 
 export enum ErrorMessage {
   NONZERO_PRICE = "NONZERO_PRICE",
-  NONZERO_AMOUNT = "NONZERO_AMOUNT",
   INSUFFICIENT_FUNDS = "INSUFFICIENT_FUNDS",
   COULD_NOT_GET_QUOTE = "COULD_NOT_GET_QUOTE",
   INSUFFICIENT_LIQUDITIY = "INSUFFICIENT_LIQUDITIY",
@@ -420,21 +419,6 @@ export const orderInputSlice = createSlice({
         bestPrice !== undefined
       ) {
         state.price = bestPrice;
-      }
-
-      // Set zero amount error
-      if (amount === 0) {
-        if (specifiedToken === SpecifiedToken.TOKEN_1) {
-          state.validationToken1 = {
-            valid: false,
-            message: ErrorMessage.NONZERO_AMOUNT,
-          };
-        } else if (specifiedToken === SpecifiedToken.TOKEN_2) {
-          state.validationToken2 = {
-            valid: false,
-            message: ErrorMessage.NONZERO_AMOUNT,
-          };
-        }
       }
 
       // Set insufficient balance for specifiedToken


### PR DESCRIPTION
Added 5 commits:

1. fixed linter error: explenation: the sliderCallback always used the isMarketOrder or isLimitOrder from OUTSIDE of its function definition. This means, that every time the order type changed, the sliderCallback function definition was redefined and recomputed. This means that we don't actually need the second input (type), as it was never used. To prevent the sliderCallback from re-computing every time the order type changes, I added useCallback, which caches each sliderCallback definition and reduces recomputation costs.

2. Fixed the error where the slider set to 0 would lead to "AMOUNT MUST BE > 0" error. This was actually expected and wanted behavior, in the context of the slider it was unpractical, so I removed this validation and instead simply made the button disabled if a non-zero amount is inputtet.

3. Moved slider below the input fields in MARKET orders, I believe you had an outdated design file.

4. The slider was very high contrast and drawing a lot of emphasis. I reduced it by adding opacity 70%.

5. I added a feature where the user can click on the % labels and the slider will automatically adapt. 

I could have done all separate PRs but think for the sake of simplicity (and syncing mess) packed everything inside a single PR! :) Please merge if you agree with the changes, otherwise lets discuss here or via discord!