### PR TITLE
Fix division by zero error - Issue_587

### DIFF
--- a/src/app/components/OrderBook.tsx
+++ b/src/app/components/OrderBook.tsx
@@ -249,10 +249,10 @@ function RecentTradesTab() {
         </thead>
 
         {lastTrades.map((trade, indx) => {
-          const price = Calculator.divide(
-            trade.token2Amount,
-            trade.token1Amount
-          );
+          const price =
+            trade.token1Amount === 0
+              ? 0
+              : Calculator.divide(trade.token2Amount, trade.token1Amount);
           const time = trade.timestamp.split("T").join(" ").split(":00.")[0];
           const amount = Math.round(trade.token1Amount);
           return (


### PR DESCRIPTION
when trade.token1Amount being zero, division by zero occurs on Recent Orders view. This change check whether it's zero, it's return 0.