### PR TITLE
fix logo for details page as well

### DIFF
--- a/src/app/rewards/page.tsx
+++ b/src/app/rewards/page.tsx
@@ -22,6 +22,7 @@ import { getTokenRewards, getTypeRewards } from "../state/rewardUtils";
 
 // import * as adex from "alphadex-sdk-js";
 import { DexterToast } from "../components/DexterToaster";
+import { DEXTER_LOGO_URL } from "utils";
 
 export default function Rewards() {
   const { showSuccessUi } = useAppSelector((state) => state.rewardSlice);
@@ -199,7 +200,11 @@ function RewardsOverview() {
           key={indx}
         >
           <img
-            src={rewardToken.iconUrl}
+            src={
+              rewardToken.symbol === "DEXTR"
+                ? DEXTER_LOGO_URL
+                : rewardToken.iconUrl
+            }
             alt={rewardToken.name}
             className="w-7 h-7 rounded-full mr-3"
           ></img>
@@ -312,7 +317,11 @@ function RewardsDetails() {
                   key={indx2}
                 >
                   <img
-                    src={tokenReward.iconUrl}
+                    src={
+                      tokenReward.symbol === "DEXTR"
+                        ? DEXTER_LOGO_URL
+                        : tokenReward.iconUrl
+                    }
                     alt={tokenReward.name}
                     className="w-4 h-4 rounded-full mr-2"
                   ></img>

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -2,6 +2,9 @@ import * as adex from "alphadex-sdk-js";
 import { TokenInfo } from "./state/pairSelectorSlice";
 import type { OrderReceipt } from "alphadex-sdk-js";
 
+export const DEXTER_LOGO_URL =
+  "https://assets.coingecko.com/coins/images/34946/standard/DEXTRLogo.jpg";
+
 export function displayPositiveNumber(
   x: number,
   noDigits: number = 6,
@@ -315,7 +318,7 @@ export function updateIconIfNeeded(token: adex.TokenInfo): TokenInfo {
   const iconUrl =
     token.symbol === "DEXTR"
       ? // use asset from coingecko to prevent ipfs failure
-        "https://assets.coingecko.com/coins/images/34946/standard/DEXTRLogo.jpg"
+        DEXTER_LOGO_URL
       : token.symbol === "RDK"
       ? // fix wrong icon URL in metadata ofRDK on ledger, see https://t.me/radix_dlt/716425
         "https://radket.shop/img/logo.svg"


### PR DESCRIPTION
Fixed the missing DeXter logo on the rewards page. 

The IPFS node seems to be down, so decided to hardcode the icon url only for DeXter.

Reported here:
https://t.me/dexter_discussion/21047