### PR TITLE
Improve pageload

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,4 +179,3 @@ To add a new banner, follow these steps:
 3. If you are the designer creating the banner, the content needs to be delivered as an SVG with a transparent background (see examples for [desktop](https://github.com/DeXter-on-Radix/website/blob/main/public/promo-banners/validator-node-staking/desktop-600x80.svg) or [mobile](https://github.com/DeXter-on-Radix/website/blob/main/public/promo-banners/validator-node-staking/mobile-600x200.svg)). Furthermore, ensure there is only a single call to action (CTA). Avoid having multiple competing actions like "STAKE NOW" and "learn more". Decide which one is more important and design the banner accordingly :D
 4. Upload both files to `/public/promo-banners/`.
 5. Fill out `imageUrl`, `imageUrlMobile` and optionally `redirecturl` inside [`src/app/layout.tsx`](https://github.com/DeXter-on-Radix/website/blob/main/src/app/layout.tsx#L15-L20).
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,36 +180,3 @@ To add a new banner, follow these steps:
 4. Upload both files to `/public/promo-banners/`.
 5. Fill out `imageUrl`, `imageUrlMobile` and optionally `redirecturl` inside [`src/app/layout.tsx`](https://github.com/DeXter-on-Radix/website/blob/main/src/app/layout.tsx#L15-L20).
 
-## Hydration Error Handling
-
-**Problem**
-
-State variables get cached, leading to unpredictable initial renders of components (e.g., initialization based on cookies). This violates React/NextJS patterns and triggers hydration errors.
-
-**Handling Hydration Errors**
-
-1. **No Error**: If no hydration error occurs, no action is needed.
-2. **Error Detected**: Identify the component causing the error.
-3. **Fixing the Component**: Add the following code to the problematic component:
-
-```tsx
-import { useHydrationErrorFix } from "hooks";
-
-function ComponentWithHydrationError() {
-  const isClient = useHydrationErrorFix();
-
-  // Additional code like useEffect or other hooks go here!
-  // ...
-
-  if (!isClient) return <></>;
-
-  return (
-    /* Your component JSX */
-  );
-}
-```
-
-**Common Causes of Hydration Errors**
-
-1. **Radix Connect Button**: Caches logged-in users. Components relying on login status will render differently based on the user's login state.
-2. **Language Detection**: Cached in cookies. Components will render differently for users from various regions based on their browser-detected language.

--- a/src/app/components/DexterButton.tsx
+++ b/src/app/components/DexterButton.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useAppDispatch } from "hooks";
-import { i18nSlice } from "state/i18nSlice";
 import { twMerge } from "tailwind-merge";
 
 interface DexterButtonProps {

--- a/src/app/components/DexterButton.tsx
+++ b/src/app/components/DexterButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useHydrationErrorFix } from "hooks";
+import { useAppDispatch, useHydrationErrorFix, useLanguageSwitch } from "hooks";
+import { i18nSlice } from "state/i18nSlice";
 import { twMerge } from "tailwind-merge";
 
 interface DexterButtonProps {
@@ -24,9 +25,11 @@ export function DexterButton({
   buttonClassName = "",
   labelClassName = "",
 }: DexterButtonProps) {
-  const isClient = useHydrationErrorFix();
-
-  if (!isClient) return null;
+  const maybLanguage = useLanguageSwitch();
+  const dispatch = useAppDispatch();
+  if (maybLanguage) {
+    dispatch(i18nSlice.actions.changeLanguage(maybLanguage));
+  }
 
   const wrapperDefaultClassName = `z-100 min-w-[220px] max-${maxWidth}`;
   const buttonDefaultClassName = `min-${minHeight} ${maxWidth} px-4 mb-6 mt-8 rounded bg-dexter-green-OG text-black uppercase opacity-100`;

--- a/src/app/components/DexterButton.tsx
+++ b/src/app/components/DexterButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useAppDispatch, useHydrationErrorFix, useLanguageSwitch } from "hooks";
+import { useAppDispatch } from "hooks";
 import { i18nSlice } from "state/i18nSlice";
 import { twMerge } from "tailwind-merge";
 
@@ -25,12 +25,6 @@ export function DexterButton({
   buttonClassName = "",
   labelClassName = "",
 }: DexterButtonProps) {
-  const maybLanguage = useLanguageSwitch();
-  const dispatch = useAppDispatch();
-  if (maybLanguage) {
-    dispatch(i18nSlice.actions.changeLanguage(maybLanguage));
-  }
-
   const wrapperDefaultClassName = `z-100 min-w-[220px] max-${maxWidth}`;
   const buttonDefaultClassName = `min-${minHeight} ${maxWidth} px-4 mb-6 mt-8 rounded bg-dexter-green-OG text-black uppercase opacity-100`;
   const labelDefaultClassName = "font-bold text-sm tracking-[.1px]";

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -6,7 +6,7 @@ import { useSelector } from "react-redux";
 import {
   useAppDispatch,
   useAppSelector,
-  useHydrationErrorFix,
+  useIsMobile,
   useTranslations,
 } from "hooks";
 import { getSupportedLanguagesAsString } from "../state/i18nSlice";
@@ -16,7 +16,7 @@ import { radixSlice } from "../state/radixSlice";
 
 import Cookies from "js-cookie";
 import { usePathname } from "next/navigation";
-import { isMobile, shortenWalletAddress } from "../utils";
+import { shortenWalletAddress } from "../utils";
 import {
   fetchAccountHistory,
   accountHistorySlice,
@@ -272,9 +272,7 @@ function MobileMenu({
   menuOpen: boolean;
   setMenuOpen: (newMenuOpen: boolean) => void;
 }) {
-  const isClient = useHydrationErrorFix();
-  if (!isClient) return null;
-
+  const isMobile = useIsMobile();
   return (
     <div
       className={`flex flex-col 
@@ -285,7 +283,7 @@ function MobileMenu({
           fixed top-0 left-0 
           py-5
           bg-[rgba(0,0,0,0.8)] backdrop-blur-lg
-           ${isMobile() ? "px-6" : "px-10"}
+           ${isMobile ? "px-6" : "px-10"}
             ${
               menuOpen
                 ? "opacity-100 scale-100"

--- a/src/app/components/OrderInput.tsx
+++ b/src/app/components/OrderInput.tsx
@@ -8,12 +8,7 @@ import {
   truncateWithPrecision,
 } from "../utils";
 
-import {
-  useAppDispatch,
-  useAppSelector,
-  useTranslations,
-  useHydrationErrorFix,
-} from "hooks";
+import { useAppDispatch, useAppSelector, useTranslations } from "hooks";
 import { fetchBalances } from "state/pairSelectorSlice";
 import {
   OrderSide,
@@ -360,7 +355,6 @@ function PostOnlyCheckbox() {
 }
 
 function SubmitButton() {
-  const isClient = useHydrationErrorFix(); // to fix HydrationError
   const t = useTranslations();
   const dispatch = useAppDispatch();
   const {
@@ -390,9 +384,6 @@ function SubmitButton() {
         .replaceAll("<$ORDER_TYPE>", t(type))
         .replaceAll("<$SIDE>", t(side))
         .replaceAll("<$TOKEN_SYMBOL>", token1.symbol);
-
-  // Fix HydrationError
-  if (!isClient) return <></>;
 
   return (
     <button

--- a/src/app/hooks.ts
+++ b/src/app/hooks.ts
@@ -3,9 +3,11 @@ import type { TypedUseSelectorHook } from "react-redux";
 import type { RootState, AppDispatch } from "./state/store";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
+  detectBrowserLanguage,
   getLocalStoragePaginationValue,
   setLocalStoragePaginationValue,
 } from "utils";
+import Cookies from "js-cookie";
 
 // https://redux-toolkit.js.org/tutorials/typescript#define-typed-hooks
 export const useAppDispatch: () => AppDispatch = useDispatch;
@@ -22,6 +24,22 @@ export const useTranslations = () => {
     return textContent[currentLanguage]?.[key] || key;
   };
   return t;
+};
+
+// Hook to change language after hydration process
+export const useLanguageSwitch = () => {
+  const userLanguageCookieValue = Cookies.get("userLanguage");
+  const { textContent } = useAppSelector((state) => state.i18n);
+  const supportedLanguages = Object.keys(textContent);
+  if (userLanguageCookieValue) {
+    return userLanguageCookieValue;
+  } else {
+    const browserLang = detectBrowserLanguage();
+    if (supportedLanguages.includes(browserLang)) {
+      return browserLang;
+    }
+  }
+  return undefined;
 };
 
 // Hook to fix hydration errors by delaying rendering until client-side mount

--- a/src/app/hooks.ts
+++ b/src/app/hooks.ts
@@ -3,11 +3,17 @@ import type { TypedUseSelectorHook } from "react-redux";
 import type { RootState, AppDispatch } from "./state/store";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
-  detectBrowserLanguage,
   getLocalStoragePaginationValue,
   setLocalStoragePaginationValue,
 } from "utils";
-import Cookies from "js-cookie";
+
+// Define an enum for the operating system types
+export enum OperatingSystem {
+  MAC = "MAC",
+  WINDOWS = "WINDOWS",
+  LINUX = "LINUX",
+  UNKNOWN = "UNKNOWN",
+}
 
 // https://redux-toolkit.js.org/tutorials/typescript#define-typed-hooks
 export const useAppDispatch: () => AppDispatch = useDispatch;
@@ -26,32 +32,92 @@ export const useTranslations = () => {
   return t;
 };
 
-// Hook to change language after hydration process
-export const useLanguageSwitch = () => {
-  const userLanguageCookieValue = Cookies.get("userLanguage");
-  const { textContent } = useAppSelector((state) => state.i18n);
-  const supportedLanguages = Object.keys(textContent);
-  if (userLanguageCookieValue) {
-    return userLanguageCookieValue;
-  } else {
-    const browserLang = detectBrowserLanguage();
-    if (supportedLanguages.includes(browserLang)) {
-      return browserLang;
-    }
-  }
-  return undefined;
-};
-
-// Hook to fix hydration errors by delaying rendering until client-side mount
-export const useHydrationErrorFix = () => {
-  const [isClient, setIsClient] = useState(false);
-
+export const useIsMobile = () => {
+  const [isMobile, setIsMobile] = useState(false);
   useEffect(() => {
-    setIsClient(true);
+    const checkIfMobile = () => {
+      try {
+        const userAgent = navigator.userAgent.toLowerCase();
+        if (
+          userAgent.match(/Android/i) ||
+          userAgent.match(/webOS/i) ||
+          userAgent.match(/avantgo/i) ||
+          userAgent.match(/iPhone/i) ||
+          userAgent.match(/iPad/i) ||
+          userAgent.match(/iPod/i) ||
+          userAgent.match(/BlackBerry/i) ||
+          userAgent.match(/bolt/i) ||
+          userAgent.match(/Windows Phone/i) ||
+          userAgent.match(/Phone/i)
+        ) {
+          return true;
+        }
+        return false;
+      } catch (err) {
+        console.error(err);
+        return window.innerWidth < 768;
+      }
+    };
+    setIsMobile(checkIfMobile());
   }, []);
-
-  return isClient;
+  return isMobile;
 };
+
+export const useOperatingSystem = () => {
+  const [operatingSystem, setOperatingSystem] = useState<OperatingSystem>(
+    OperatingSystem.UNKNOWN
+  );
+  useEffect(() => {
+    const detectOperatingSystem = (): OperatingSystem => {
+      if (typeof window === "undefined" || typeof navigator === "undefined") {
+        return OperatingSystem.UNKNOWN;
+      }
+      const userAgent = navigator.userAgent.toLowerCase();
+      if (userAgent.includes("mac os")) {
+        return OperatingSystem.MAC;
+      } else if (userAgent.includes("windows")) {
+        return OperatingSystem.WINDOWS;
+      } else if (userAgent.includes("linux")) {
+        return OperatingSystem.LINUX;
+      } else {
+        return OperatingSystem.UNKNOWN;
+      }
+    };
+    const os = detectOperatingSystem();
+    setOperatingSystem(os);
+  }, []);
+  return operatingSystem;
+};
+
+export function useBrowserLanguage(defaultLanguage: string = "en") {
+  const [language, setLanguage] = useState<string>(defaultLanguage);
+  const detectBrowserLanguage = (defaultLanguage: string = "en"): string => {
+    const toLngCode = (str: string) => str.substring(0, 2).toLowerCase();
+    if (typeof window !== "undefined" && typeof navigator !== "undefined") {
+      if (Array.isArray(navigator.languages) && navigator.languages.length) {
+        return toLngCode(navigator.languages[0]);
+      }
+      if (navigator.language) {
+        return toLngCode(navigator.language);
+      }
+      if ((navigator as any).userLanguage) {
+        return toLngCode((navigator as any).userLanguage);
+      }
+      if ((navigator as any).browserLanguage) {
+        return toLngCode((navigator as any).browserLanguage);
+      }
+      if ((navigator as any).systemLanguage) {
+        return toLngCode((navigator as any).systemLanguage);
+      }
+    }
+    return defaultLanguage;
+  };
+  useEffect(() => {
+    const browserLanguage = detectBrowserLanguage(defaultLanguage);
+    setLanguage(browserLanguage);
+  }, [defaultLanguage]);
+  return language;
+}
 
 export function usePagination<T>(data: T[], paginationId?: string) {
   const [currentPage, setCurrentPage] = useState(0);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,7 @@ import { Navbar } from "./components/NavBar";
 import { Provider } from "react-redux";
 import { usePathname } from "next/navigation";
 import { DexterToaster } from "./components/DexterToaster";
-import { useEffect, Suspense, useState } from "react";
+import { useEffect, Suspense } from "react";
 import { initializeSubscriptions, unsubscribeAll } from "./subscriptions";
 import { store } from "./state/store";
 import { useAppDispatch, useAppSelector, useBrowserLanguage } from "hooks";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -52,19 +52,21 @@ function AppBody({ children }: { children: React.ReactNode }) {
   const path = usePathname();
 
   // Detect browser langauge
-  const { textContent } = useAppSelector((state) => state.i18n);
-  const supportedLanguages = Object.keys(textContent);
+  // const { textContent } = useAppSelector((state) => state.i18n);
+  // const supportedLanguages = Object.keys(textContent);
   useEffect(() => {
-    const userLanguageCookieValue = Cookies.get("userLanguage");
-    if (userLanguageCookieValue) {
-      dispatch(i18nSlice.actions.changeLanguage(userLanguageCookieValue));
-    } else {
-      const browserLang = detectBrowserLanguage();
-      if (supportedLanguages.includes(browserLang)) {
-        dispatch(i18nSlice.actions.changeLanguage(browserLang));
-      }
-    }
-  }, [dispatch, supportedLanguages]);
+    dispatch(i18nSlice.actions.changeLanguage("en"));
+
+    // const userLanguageCookieValue = Cookies.get("userLanguage");
+    // if (userLanguageCookieValue) {
+    //   dispatch(i18nSlice.actions.changeLanguage(userLanguageCookieValue));
+    // } else {
+    //   const browserLang = detectBrowserLanguage();
+    //   if (supportedLanguages.includes(browserLang)) {
+    //     dispatch(i18nSlice.actions.changeLanguage(browserLang));
+    //   }
+    // }
+  }, [dispatch]);
 
   return (
     <body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,7 @@ import { store } from "./state/store";
 import { useAppDispatch, useAppSelector, useBrowserLanguage } from "hooks";
 import Cookies from "js-cookie";
 import { i18nSlice } from "state/i18nSlice";
+import { radixSlice } from "state/radixSlice";
 
 export default function RootLayout({
   children,
@@ -25,7 +26,7 @@ export default function RootLayout({
     return () => {
       unsubscribeAll();
     };
-  }, []);
+  });
 
   // TODO: after MVP remove "use client", fix all as many Components as possible
   // to be server components for better SSG and SEO
@@ -45,20 +46,18 @@ export default function RootLayout({
 
 // This subcomponent is needed to initialize browser language for the whole app
 function AppBody({ children }: { children: React.ReactNode }) {
-  const path = usePathname();
-
   const dispatch = useAppDispatch();
+  const path = usePathname();
+  const { isHydrated } = useAppSelector((state) => state.radix);
+
+  // set hydration globally once
+  useEffect(() => {
+    dispatch(radixSlice.actions.setIsHydrated(true));
+  }, [dispatch]);
+
   const { textContent } = useAppSelector((state) => state.i18n);
   const supportedLanguages = Object.keys(textContent);
   const browserLanguage = useBrowserLanguage();
-
-  // State to track hydration
-  const [isHydrated, setIsHydrated] = useState(false);
-
-  // Set the hydration state to true after component mounts
-  useEffect(() => {
-    setIsHydrated(true);
-  }, []);
 
   useEffect(() => {
     if (isHydrated) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -65,9 +65,9 @@ export default function Landing() {
 
 function HeroSection() {
   const t = useTranslations();
-  const isClient = useHydrationErrorFix();
+  // const isClient = useHydrationErrorFix();
 
-  if (!isClient) return <></>;
+  // if (!isClient) return <></>;
   return (
     <div
       className={
@@ -100,7 +100,7 @@ function HeroSection() {
           </h1>
           <div className="relative">
             <BackgroundLights showFor={Device.MOBILE} />
-            <DexterButton title={t("trade_now")} targetUrl="/trade" />
+            <DexterButton title={"trade nowsss"} targetUrl="/trade" />
           </div>
           <KeyFeatures showFor={Device.MOBILE} />
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { DexterButton } from "components/DexterButton";
 import StatsWidget from "components/StatsWidget";
-import { useTranslations, useHydrationErrorFix } from "hooks";
+import { useTranslations } from "hooks";
 
 enum Device {
   MOBILE = "MOBILE",
@@ -51,6 +51,7 @@ export default function Landing() {
   const tradeProps = getTopicsSectionProps(TopicSectionEnum.TRADE, t);
   const stakeProps = getTopicsSectionProps(TopicSectionEnum.STAKE, t);
   const contributeProps = getTopicsSectionProps(TopicSectionEnum.CONTRIBUTE, t);
+
   return (
     <div className="bg-dexter-grey-light">
       <HeroSection />
@@ -65,9 +66,6 @@ export default function Landing() {
 
 function HeroSection() {
   const t = useTranslations();
-  // const isClient = useHydrationErrorFix();
-
-  // if (!isClient) return <></>;
   return (
     <div
       className={
@@ -100,7 +98,7 @@ function HeroSection() {
           </h1>
           <div className="relative">
             <BackgroundLights showFor={Device.MOBILE} />
-            <DexterButton title={"trade nowsss"} targetUrl="/trade" />
+            <DexterButton title={t("trade_now")} targetUrl="/trade" />
           </div>
           <KeyFeatures showFor={Device.MOBILE} />
         </div>
@@ -223,8 +221,6 @@ function TopicSection({
   buttonText,
   reversed,
 }: TopicSectionProps): JSX.Element {
-  const isClient = useHydrationErrorFix();
-  if (!isClient) return <></>;
   return (
     <div
       className={`${backgroundColor} py-20 max-[820px]:py-10 z-[100] relative`}

--- a/src/app/rewards/page.tsx
+++ b/src/app/rewards/page.tsx
@@ -93,28 +93,15 @@ function HeaderComponent() {
 
 function RewardsCard() {
   const dispatch = useAppDispatch();
-  const { isConnected, selectedAccount } = useAppSelector(
+  const { isHydrated, isConnected, selectedAccount } = useAppSelector(
     (state) => state.radix
   );
-
-  const [isHydrated, setIsHydrated] = useState(false);
-  const [isConnectedLocal, setIsConnectedLocal] = useState(false);
   const account = selectedAccount?.address;
   const t = useTranslations();
   const { rewardData, pairsList, isLoading } = useAppSelector(
     (state) => state.rewardSlice
   );
   const userHasRewards = getUserHasRewards(rewardData);
-
-  useEffect(() => {
-    setIsHydrated(true);
-  }, []);
-
-  useEffect(() => {
-    if (isHydrated) {
-      setIsConnectedLocal(isConnected);
-    }
-  }, [isConnected, isHydrated]);
 
   useEffect(() => {
     // Performs 4 sequential actions:
@@ -136,10 +123,10 @@ function RewardsCard() {
         fetchOrderRewards(fetchReceiptsResult.payload as string[])
       );
     }
-    if (isConnectedLocal) {
+    if (isHydrated && isConnected) {
       loadRewards();
     }
-  }, [dispatch, isConnectedLocal, account, pairsList]);
+  }, [dispatch, isHydrated, isConnected, account, pairsList]);
 
   return (
     <div className="max-w-[400px] sm:max-w-[600px] px-4 py-4 sm:px-12 sm:py-8 m-auto mt-2 sm:mt-14 mb-28 bg-[#191B1D] rounded-xl max-[450px]:mx-5">
@@ -148,12 +135,12 @@ function RewardsCard() {
           <h4
             style={{ margin: 0, marginBottom: 12 }}
             className={
-              !isConnectedLocal || !userHasRewards
+              !isHydrated || !isConnected || !userHasRewards
                 ? "opacity-50 text-center"
                 : ""
             }
           >
-            {!isConnectedLocal
+            {!isHydrated || !isConnected
               ? t("connect_wallet_to_claim_rewards")
               : userHasRewards
               ? t("total_rewards")
@@ -162,13 +149,13 @@ function RewardsCard() {
               : t("no_rewards_to_claim")}
           </h4>
         </div>
-        {/* <RewardsOverview />
+        <RewardsOverview />
         <ClaimButton />
         <SecondaryAction
           textIdentifier="learn_more_about_rewards"
           targetUrl="https://dexter-on-radix.gitbook.io/dexter/overview/how-are-contributors-rewarded/liquidity-incentives"
         />
-        <RewardsDetails /> */}
+        <RewardsDetails />
       </div>
     </div>
   );
@@ -227,12 +214,12 @@ function RewardsOverview() {
 function ClaimButton() {
   const t = useTranslations();
   const dispatch = useAppDispatch();
-  const { isConnected } = useAppSelector((state) => state.radix);
+  const { isConnected, isHydrated } = useAppSelector((state) => state.radix);
   const { rewardData, isLoading } = useAppSelector(
     (state) => state.rewardSlice
   );
   const userHasRewards = getUserHasRewards(rewardData);
-  const disabled = !isConnected || !userHasRewards;
+  const disabled = !isHydrated || !isConnected || !userHasRewards;
 
   return (
     <button
@@ -270,7 +257,7 @@ function ClaimButton() {
 
 function RewardsDetails() {
   const [isOpen, setIsOpen] = useState(true);
-  const { isConnected } = useAppSelector((state) => state.radix);
+  const { isConnected, isHydrated } = useAppSelector((state) => state.radix);
   const { rewardData, tokensList } = useAppSelector(
     (state) => state.rewardSlice
   );
@@ -280,9 +267,9 @@ function RewardsDetails() {
     if (!isConnected) {
       setIsOpen(false);
     }
-  }, [isConnected]);
+  }, [isConnected, isHydrated]);
 
-  if (!isConnected || !userHasRewards) {
+  if (!isHydrated || !isConnected || !userHasRewards) {
     return <></>;
   }
 

--- a/src/app/rewards/page.tsx
+++ b/src/app/rewards/page.tsx
@@ -96,12 +96,25 @@ function RewardsCard() {
   const { isConnected, selectedAccount } = useAppSelector(
     (state) => state.radix
   );
+
+  const [isHydrated, setIsHydrated] = useState(false);
+  const [isConnectedLocal, setIsConnectedLocal] = useState(false);
   const account = selectedAccount?.address;
   const t = useTranslations();
   const { rewardData, pairsList, isLoading } = useAppSelector(
     (state) => state.rewardSlice
   );
   const userHasRewards = getUserHasRewards(rewardData);
+
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (isHydrated) {
+      setIsConnectedLocal(isConnected);
+    }
+  }, [isConnected, isHydrated]);
 
   useEffect(() => {
     // Performs 4 sequential actions:
@@ -123,10 +136,10 @@ function RewardsCard() {
         fetchOrderRewards(fetchReceiptsResult.payload as string[])
       );
     }
-    if (isConnected) {
+    if (isConnectedLocal) {
       loadRewards();
     }
-  }, [dispatch, isConnected, account, pairsList]);
+  }, [dispatch, isConnectedLocal, account, pairsList]);
 
   return (
     <div className="max-w-[400px] sm:max-w-[600px] px-4 py-4 sm:px-12 sm:py-8 m-auto mt-2 sm:mt-14 mb-28 bg-[#191B1D] rounded-xl max-[450px]:mx-5">
@@ -135,10 +148,12 @@ function RewardsCard() {
           <h4
             style={{ margin: 0, marginBottom: 12 }}
             className={
-              !isConnected || !userHasRewards ? "opacity-50 text-center" : ""
+              !isConnectedLocal || !userHasRewards
+                ? "opacity-50 text-center"
+                : ""
             }
           >
-            {!isConnected
+            {!isConnectedLocal
               ? t("connect_wallet_to_claim_rewards")
               : userHasRewards
               ? t("total_rewards")
@@ -147,13 +162,13 @@ function RewardsCard() {
               : t("no_rewards_to_claim")}
           </h4>
         </div>
-        <RewardsOverview />
+        {/* <RewardsOverview />
         <ClaimButton />
         <SecondaryAction
           textIdentifier="learn_more_about_rewards"
           targetUrl="https://dexter-on-radix.gitbook.io/dexter/overview/how-are-contributors-rewarded/liquidity-incentives"
         />
-        <RewardsDetails />
+        <RewardsDetails /> */}
       </div>
     </div>
   );

--- a/src/app/rewards/page.tsx
+++ b/src/app/rewards/page.tsx
@@ -1,12 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import {
-  useAppDispatch,
-  useAppSelector,
-  useTranslations,
-  useHydrationErrorFix,
-} from "hooks";
+import { useAppDispatch, useAppSelector, useTranslations } from "hooks";
 import {
   fetchAddresses,
   fetchReciepts,
@@ -97,7 +92,6 @@ function HeaderComponent() {
 }
 
 function RewardsCard() {
-  const isClient = useHydrationErrorFix(); // to fix HydrationError
   const dispatch = useAppDispatch();
   const { isConnected, selectedAccount } = useAppSelector(
     (state) => state.radix
@@ -133,9 +127,6 @@ function RewardsCard() {
       loadRewards();
     }
   }, [dispatch, isConnected, account, pairsList]);
-
-  // Fix HydrationError
-  if (!isClient) return <></>;
 
   return (
     <div className="max-w-[400px] sm:max-w-[600px] px-4 py-4 sm:px-12 sm:py-8 m-auto mt-2 sm:mt-14 mb-28 bg-[#191B1D] rounded-xl max-[450px]:mx-5">
@@ -219,7 +210,6 @@ function RewardsOverview() {
 }
 
 function ClaimButton() {
-  const isClient = useHydrationErrorFix(); // to fix HydrationError
   const t = useTranslations();
   const dispatch = useAppDispatch();
   const { isConnected } = useAppSelector((state) => state.radix);
@@ -228,9 +218,6 @@ function ClaimButton() {
   );
   const userHasRewards = getUserHasRewards(rewardData);
   const disabled = !isConnected || !userHasRewards;
-
-  // Fix HydrationError
-  if (!isClient) return <></>;
 
   return (
     <button
@@ -268,7 +255,6 @@ function ClaimButton() {
 
 function RewardsDetails() {
   const [isOpen, setIsOpen] = useState(true);
-  const isClient = useHydrationErrorFix(); // to fix HydrationError
   const { isConnected } = useAppSelector((state) => state.radix);
   const { rewardData, tokensList } = useAppSelector(
     (state) => state.rewardSlice
@@ -281,7 +267,7 @@ function RewardsDetails() {
     }
   }, [isConnected]);
 
-  if (!isConnected || !userHasRewards || !isClient) {
+  if (!isConnected || !userHasRewards) {
     return <></>;
   }
 

--- a/src/app/state/radixSlice.ts
+++ b/src/app/state/radixSlice.ts
@@ -12,6 +12,7 @@ export interface RadixState {
   walletData: WalletData;
   isConnected: boolean;
   selectedAccount: WalletDataStateAccount;
+  isHydrated: boolean;
 }
 
 const initialState: RadixState = {
@@ -22,6 +23,7 @@ const initialState: RadixState = {
   },
   isConnected: false,
   selectedAccount: {} as WalletDataStateAccount,
+  isHydrated: false,
 };
 
 export const radixSlice = createSlice({
@@ -43,6 +45,9 @@ export const radixSlice = createSlice({
       action: PayloadAction<WalletDataStateAccount>
     ) => {
       state.selectedAccount = action.payload;
+    },
+    setIsHydrated: (state: RadixState, action: PayloadAction<boolean>) => {
+      state.isHydrated = action.payload;
     },
   },
 });

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -349,34 +349,6 @@ export function capitalizeFirstLetter(input: string): string {
   return input.charAt(0).toUpperCase() + input.slice(1);
 }
 
-export function detectBrowserLanguage(defaultLanguage: string = "en"): string {
-  // Helper function to extract first 2 chars and ensure its lowercased.
-  const toLngCode = (str: string) => str.substring(0, 2).toLowerCase();
-
-  // navigator.languages: Returns an array of the user's preferred languages, ordered by preference
-  if (Array.isArray(navigator.languages) && navigator.languages.length) {
-    return toLngCode(navigator.languages[0]);
-  }
-  // navigator.language: Returns the browser's UI language
-  if (navigator.language) {
-    return toLngCode(navigator.language);
-  }
-  // navigator.userLanguage: Deprecated but included for compatibility with older versions of IE
-  if ((navigator as any).userLanguage) {
-    return toLngCode((navigator as any).userLanguage);
-  }
-  // navigator.browserLanguage: Another deprecated property for older IE versions
-  if ((navigator as any).browserLanguage) {
-    return toLngCode((navigator as any).browserLanguage);
-  }
-  // navigator.systemLanguage: Deprecated and for IE only, returns OS language
-  if ((navigator as any).systemLanguage) {
-    return toLngCode((navigator as any).systemLanguage);
-  }
-  // Fallback to a default language if none is detected
-  return defaultLanguage;
-}
-
 // Gets amount precision for each token traded on dexteronradix.
 // Note: precision for price is different.
 export function getPrecision(input: string): number {
@@ -426,31 +398,6 @@ export function formatNumericString(
   return fraction ? `${whole}${separator}${fraction}` : whole;
 }
 
-// Define an enum for the operating system types
-export enum OperatingSystem {
-  MAC = "MAC",
-  WINDOWS = "WINDOWS",
-  LINUX = "LINUX",
-  UNKNOWN = "UNKNOWN",
-}
-
-// Function to detect the users operating system based on navigator
-export function detectOperatingSystem(): OperatingSystem {
-  if (typeof window === "undefined" || typeof navigator === "undefined") {
-    return OperatingSystem.UNKNOWN;
-  }
-  const userAgent = navigator.userAgent.toLowerCase();
-  if (userAgent.includes("mac os")) {
-    return OperatingSystem.MAC;
-  } else if (userAgent.includes("windows")) {
-    return OperatingSystem.WINDOWS;
-  } else if (userAgent.includes("linux")) {
-    return OperatingSystem.LINUX;
-  } else {
-    return OperatingSystem.UNKNOWN;
-  }
-}
-
 export function truncateWithPrecision(num: number, precision: number): number {
   const split = num.toString().split(".");
   if (split.length !== 2) {
@@ -458,26 +405,6 @@ export function truncateWithPrecision(num: number, precision: number): number {
   }
   const [part1, part2] = split;
   return Number(`${part1}.${part2.substring(0, precision)}`);
-}
-
-// Detects mobile devices
-export function isMobile(): boolean {
-  const userAgent = navigator.userAgent.toLowerCase();
-  if (
-    userAgent.match(/Android/i) ||
-    userAgent.match(/webOS/i) ||
-    userAgent.match(/avantgo/i) ||
-    userAgent.match(/iPhone/i) ||
-    userAgent.match(/iPad/i) ||
-    userAgent.match(/iPod/i) ||
-    userAgent.match(/BlackBerry/i) ||
-    userAgent.match(/bolt/i) ||
-    userAgent.match(/Windows Phone/i) ||
-    userAgent.match(/Phone/i)
-  ) {
-    return true;
-  }
-  return false;
 }
 
 // Sets a URL query parameter and updates the browser's history state


### PR DESCRIPTION
### Summary
This PR includes several important refactors and fixes related to client-side rendering and hydration handling. If reviewing is difficult, I'm happy to split it into smaller PRs or explain via a quick call.

### Changes:
- **Refactored utility functions to hooks**: Functions that relied on the `navigator` object are now client-side hooks for better safety and cleaner code. 
  - `detectBrowserLanguage` → `useBrowserLanguage()`
  - `isMobile` → `useMobile()`
  - `detectOperatingSystem` → `useOperatingSystem()`
  
- **Improved hydration handling**: 
  - Previous approach: Rendered an empty component until hydration was complete, then populated content.
  - New approach: The default page (in English) is rendered with all UI elements during initial pageload. Once hydration completes, the saved language from cookies is applied. This improves SEO but causes a brief flash if a non-default language is selected (e.g., English flashes before switching to Portuguese).
  
- **Connect button hydration fix**: 
  - Added a global `isHydrated` flag. Conditional rendering for the connect button now depends on both `isConnected && isHydrated`. This avoids rendering empty content but may still cause a brief flash of default text ("Connect wallet") during hydration.

- Removed the previous `useHydrationFix` hook entirely and cleaned up the related documentation.

### This PR significantly enhances initial page load, resulting in improved UX and SEO across all pages, as demonstrated by the following examples.

**LANDING PAGE**
**before**
<img width="500" alt="Bildschirmfoto 2024-10-18 um 21 59 50" src="https://github.com/user-attachments/assets/60791f20-778f-4beb-8674-0c50506217f8">
**after**
<img width="500" alt="Bildschirmfoto 2024-10-18 um 21 59 41" src="https://github.com/user-attachments/assets/033e4bd9-014d-48ab-b12f-175016fd4736">

**TRADE PAGE**
**before**
<img width="500" alt="Bildschirmfoto 2024-10-18 um 22 00 16" src="https://github.com/user-attachments/assets/be077b65-64f1-49ab-b2f3-537910c20d31">
**after**
<img width="500" alt="Bildschirmfoto 2024-10-18 um 22 00 07" src="https://github.com/user-attachments/assets/d2dcdb4e-59f6-47d7-bc5d-9992ab43aa86">
