### PR TITLE
fix team page layout shifts

### DIFF
--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -21,7 +21,7 @@ export default function Team() {
   }, [dispatch]);
 
   return (
-    <div className="bg-dexter-grey-dark grow flex items-center justify-center pt-10">
+    <div className="bg-dexter-grey-dark grow flex items-start justify-center pt-10">
       <div className="max-w-[1200px] p-8">
         <HeaderComponent />
         <Filters />


### PR DESCRIPTION
Currently, when the user explores the contributors list by clicking the filters, the layout shifts, as the content is always being centered, and depending on filter, the content is vigger / smaller. 

This PR makes the layout always start from top, which remoevs the layout shifts, as the filter UI will always show up in the same place. 

### ❌Before


https://github.com/user-attachments/assets/a0c77629-af56-4a4c-91dc-599d76466182

### ✅After

https://github.com/user-attachments/assets/b9e15c7b-74d5-4578-91ad-0d247b5c8f17

