### PR TITLE
Fix buy sell panel slider tests

### DIFF
--- a/src/app/state/orderInputSlice.test.ts
+++ b/src/app/state/orderInputSlice.test.ts
@@ -66,32 +66,6 @@ describe("OrderInputSlice", () => {
     );
   });
 
-  it("Validation works for zero token1 amount", () => {
-    store.dispatch(
-      orderInputSlice.actions.setTokenAmount({
-        amount: 0,
-        specifiedToken: SpecifiedToken.TOKEN_1,
-      })
-    );
-    expect(store.getState().orderInput.validationToken1.valid).toBe(false);
-    expect(store.getState().orderInput.validationToken1.message).toBe(
-      ErrorMessage.NONZERO_AMOUNT
-    );
-  });
-
-  it("Validation works for zero token2 amount", () => {
-    store.dispatch(
-      orderInputSlice.actions.setTokenAmount({
-        amount: 0,
-        specifiedToken: SpecifiedToken.TOKEN_2,
-      })
-    );
-    expect(store.getState().orderInput.validationToken2.valid).toBe(false);
-    expect(store.getState().orderInput.validationToken2.message).toBe(
-      ErrorMessage.NONZERO_AMOUNT
-    );
-  });
-
   it("Validation works for insufficient balance for token1 on sell order ", () => {
     store.dispatch(orderInputSlice.actions.setSide(OrderSide.SELL));
     store.dispatch(


### PR DESCRIPTION
The slider introduces a new UX, which makes the validation of zero token amounts tedious, because its not uncommon to set the slider back to 0. 

Since we don't want to trigger the error every time the user uses the slider, I think its fine to remove those tests, as the validation was removed as well.