### PR TITLE
update tokenomics on landing page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -326,7 +326,7 @@ function getTokenomicsTopicSectionProps(
       <IconTitleAndBody
         icon="money"
         title={t("tokenomics")}
-        body={t("100k_dextr_minted_every_2")}
+        body={t("max_supply_14_5_m")}
       />
       <IconTitleAndBody
         icon="vote"

--- a/src/app/state/locales/en/landing.json
+++ b/src/app/state/locales/en/landing.json
@@ -6,7 +6,7 @@
   "earn_rewards_by_trading": "Earn rewards by trading",
   "dextr_token": "$DEXTR Token",
   "tokenomics": "Tokenomics",
-  "100k_dextr_minted_every_2": "100'000 $DEXTR minted every 2 weeks. No max supply, but ~26M in 10 years at current rate.",
+  "max_supply_14_5_m": "Max supply: 14.5M tokens. Currently, 100k DEXTR are minted biweekly, with emissions linearly decreasing until ending in 2032.",
   "vote_in_the_dao": "Vote in the DAO",
   "1_dextr_equals_1_vote": "1 $DEXTR equals 1 vote in governance decisions.",
   "revenue_share_coming_soon": "Revenue share (Coming soon...)",

--- a/src/app/state/locales/pt/landing.json
+++ b/src/app/state/locales/pt/landing.json
@@ -6,7 +6,7 @@
   "earn_rewards_by_trading": "Ganhe recompensas negociando",
   "dextr_token": "Token $DEXTR",
   "tokenomics": "Tokenomics",
-  "100k_dextr_minted_every_2": "100.000 $DEXTR cunhados a cada 2 semanas. Sem limite máximo, mas ~26M em 10 anos na taxa atual.",
+  "max_supply_14_5_m": "Suprimento máximo: 14,5M tokens. Atualmente, 100k DEXTR são cunhados quinzenalmente, com emissões diminuindo linearmente até cessarem em 2032.",
   "vote_in_the_dao": "Vote no DAO",
   "1_dextr_equals_1_vote": "1 $DEXTR equivale a 1 voto em decisões de governança.",
   "revenue_share_coming_soon": "Participação de receita (Em breve...)",


### PR DESCRIPTION
Updated the text on the landing page concerning tokenomics to include the latest DAO vote to cap supply at 14.5M tokens:

**english**
<img width="468" alt="Bildschirmfoto 2024-11-09 um 02 21 21" src="https://github.com/user-attachments/assets/c425784b-b554-419b-b008-49da5c282804">

**portuguese**
<img width="481" alt="Bildschirmfoto 2024-11-09 um 02 21 56" src="https://github.com/user-attachments/assets/421d4c57-c7f0-4e59-b86b-e5bd891bc51d">
