### PR TITLE
BUG REPORT + FIX: Selecting pairs other than DEXTR/XRD silently crashed app

### DIFF
--- a/src/app/components/OrderInput.tsx
+++ b/src/app/components/OrderInput.tsx
@@ -26,6 +26,7 @@ import {
   pairAddressIsSet,
   priceIsValid,
   tokenIsSpecified,
+  amountIsPositive,
   submitOrder,
 } from "state/orderInputSlice";
 import { Calculator } from "services/Calculator";
@@ -118,7 +119,8 @@ export function OrderInput() {
     if (
       pairAddressIsSet(pairAddress) &&
       priceIsValid(price, type) &&
-      tokenIsSpecified(specifiedToken)
+      tokenIsSpecified(specifiedToken) &&
+      amountIsPositive(specifiedToken, token1, token2)
     ) {
       dispatch(fetchQuote());
     }

--- a/src/app/state/orderInputSlice.ts
+++ b/src/app/state/orderInputSlice.ts
@@ -216,6 +216,19 @@ export function tokenIsSpecified(specifiedToken: SpecifiedToken): boolean {
   return specifiedToken !== SpecifiedToken.UNSPECIFIED;
 }
 
+export function amountIsPositive(
+  specifiedToken: SpecifiedToken,
+  token1: TokenInput,
+  token2: TokenInput
+): boolean {
+  if (specifiedToken === SpecifiedToken.TOKEN_1) {
+    return token1.amount > 0;
+  } else if (specifiedToken === SpecifiedToken.TOKEN_2) {
+    return token2.amount > 0;
+  }
+  return false;
+}
+
 // for getting balances out of pairSelector slice
 // TODO(dcts): ask @chaotic whether this can live inside pairSelector now that
 // the orderInputState seems not to be needed anymore.


### PR DESCRIPTION
### Bugreport

reported by [@RenatoBro on telegram](https://t.me/dexter_discussion/21992):
- whenever the token is changed via pairSelector, the app stops working properly (silently crashes without notifying user).
- users no longer can place orders or see the chart data

### Cause

This bug was introduced with the Slider UI. Some explenations:
- the getQuote API from alphadex API seems to throw an error when the amount is 0, but only for mainnet (not on stokenet). Just out of curiosity: Is this true/possible @fliebenberg?
- we removed the validation tests for ZERO AMOUNT in the PR, because the slider would trigger that ERROR too often, making the UX bad. Based on that new UX with the slider, we decided to no longer throw an error if the amount is zero. Unfortunately I did not update the getQuote call.
- once I added the validation (in the code, not user facing) back in, everything seems to be resolved. 

### Bounty Suggestion

MEDIUM bug, 1000 DEXTR, payed out to @RenatoBro. Reason:
"Performance decreasing bugs, UI bugs that affect/block core functionality (e.g. cannot place orders, cannot vote or similar)" -> 1000 DEXTR
