### PR TITLE
Changing the alphadex init function to use alphadexApiUrlIndex=1

### DIFF
--- a/src/app/subscriptions.ts
+++ b/src/app/subscriptions.ts
@@ -111,7 +111,7 @@ export function initializeSubscriptions(store: AppStore) {
       network = adex.ApiNetworkOptions.indexOf("stokenet");
   }
 
-  adex.init(adex.ApiNetworkOptions[network]);
+  adex.init(adex.ApiNetworkOptions[network], 1);
   subs.push(
     adex.clientState.stateChanged$.subscribe((newState) => {
       const serializedState: adex.StaticState = JSON.parse(


### PR DESCRIPTION
There seems to be a potential certificate error with api.alphadex.net that is causing the system to bounce between api and api2
resolves #612 