### PR TITLE
Debounce slider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,8 @@
         "resize-observer-polyfill": "^1.5.1",
         "tailwind-merge": "^2.4.0",
         "tailwindcss": "3.3.2",
-        "typescript": "5.1.6"
+        "typescript": "5.1.6",
+        "use-debounce": "^10.0.4"
       },
       "devDependencies": {
         "@playwright/test": "^1.37.1",
@@ -9610,6 +9611,18 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-debounce": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.0.4.tgz",
+      "integrity": "sha512-6Cf7Yr7Wk7Kdv77nnJMf6de4HuDE4dTxKij+RqE9rufDsI6zsbjyAxcH5y2ueJCQAnfgKbzXbZHYlkFwmBlWkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "resize-observer-polyfill": "^1.5.1",
     "tailwind-merge": "^2.4.0",
     "tailwindcss": "3.3.2",
-    "typescript": "5.1.6"
+    "typescript": "5.1.6",
+    "use-debounce": "^10.0.4"
   },
   "devDependencies": {
     "@playwright/test": "^1.37.1",


### PR DESCRIPTION
Fixes one issue of #610 , where the slider did cause the UI to randomly change values, becuase there were a ton of requests to getQuote lined up (on every change of the slider, so for 1 slide you would get like 20-50 requests). This is also leading to extensive data usage and slows down UX. 

This fix solves that issue by adding a debounce of 350ms to all slider actions, meaning the slider will call getQuote only after it hasnt been touched for 350ms.