### PR TITLE
add rakoon-revenue shortlink

### DIFF
--- a/src/app/rakoon-revenue/page.tsx
+++ b/src/app/rakoon-revenue/page.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+const RakoonRevenue = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.push(
+      "https://docs.google.com/spreadsheets/d/1xyEob71d5c2eHuQjq1P60DXaAeeuboB2nSQFztiWviU/edit?usp=sharing"
+    );
+  }, [router]);
+
+  return null;
+};
+
+export default RakoonRevenue;


### PR DESCRIPTION
dexteronradix.com/rakoon-revenue will now redirect to the public google sheet tracking all revenue share transactions from rakoon fun.

This is the public google sheet:
https://docs.google.com/spreadsheets/d/1xyEob71d5c2eHuQjq1P60DXaAeeuboB2nSQFztiWviU/edit?gid=0#gid=0
